### PR TITLE
Update macro list

### DIFF
--- a/documentation/usersguide/macrolist.md
+++ b/documentation/usersguide/macrolist.md
@@ -1500,7 +1500,7 @@ If a next valid time cannot be found in the specified timeperiod, the macro will
 </tr>
 <tr>
 <td class="MacroName"><a name="user">$USERn$</a></td>
-<td class="MacroDescription">The <i>n</i>th user-definable macro. User macros can be defined in one or more <a href="configmain.html#resource_file">resource files</a>. Naemon supports up to 256 user macros ($USER1$ through $USER32$).</td>
+<td class="MacroDescription">The <i>n</i>th user-definable macro. User macros can be defined in one or more <a href="configmain.html#resource_file">resource files</a>. Naemon supports up to 256 user macros ($USER1$ through $USER256$).</td>
 </tr>
 </table>
 


### PR DESCRIPTION
Put in correct number of possible `$USERx$` variables.

For what it's worth here is the same issue on the Nagios tracker which I don't think has been fixed yet:

http://tracker.nagios.org/view.php?id=557

Here is a thread about the issue as well:

http://support.nagios.com/forum/viewtopic.php?f=7&t=24946

Also, confirmed the allowed `$USERx$` macros is actually `256` in Naemon:

https://github.com/naemon/naemon-core/blob/master/naemon/macros.h#L14
