### PR TITLE
pluginapi: Drop mention of Naemon 3

### DIFF
--- a/documentation/usersguide/pluginapi.md
+++ b/documentation/usersguide/pluginapi.md
@@ -40,7 +40,7 @@ Naemon determines the status of a host or service by evaluating the return code 
 
 ### Plugin Output Spec
 
-At a minimum, plugins should return at least one of text output.  Beginning with Naemon 3, plugins can optionally return multiple lines of output.  Plugins may also return optional performance data that can be processed by external applications.  The basic format for plugin output is shown below:
+At a minimum, plugins should return at least one of text output.  Optionally, plugins may return multiple lines of output.  Plugins may also return optional performance data that can be processed by external applications.  The basic format for plugin output is shown below:
 
 <p><font color="red">TEXT OUTPUT</font> | <font color="#FFA500">OPTIONAL PERFDATA</font><br>
 <font color="blue">LONG TEXT LINE 1<br>


### PR DESCRIPTION
I'm guessing this is just an accidental sed gone wild or something.
Anyways, I don't feel we're obliged to mention historical changes to
the Nagios API either way, so let's just say that multiple output is
optional and be done with it.

Let's keep it simple, eh?

Signed-off-by: Anton Lofgren alofgren@op5.com
