### PR TITLE
Requires naemon-tools to install

### DIFF
--- a/documentation/usersguide/quickstart-centos.md
+++ b/documentation/usersguide/quickstart-centos.md
@@ -61,6 +61,7 @@ wget http://labs.consol.de/naemon/release/v{{ site.release_version }}/rhel6/x86_
 wget http://labs.consol.de/naemon/release/v{{ site.release_version }}/rhel6/x86_64/naemon-thruk-{{ site.release_version }}-1.rhel6.x86_64.rpm
 wget http://labs.consol.de/naemon/release/v{{ site.release_version }}/rhel6/x86_64/naemon-{{ site.release_version }}-1.rhel6.x86_64.rpm
 wget http://labs.consol.de/naemon/release/v{{ site.release_version }}/rhel6/x86_64/libnaemon-{{ site.release_version }}-1.rhel6.x86_64.rpm
+wget http://labs.consol.de/naemon/release/v{{ site.release_version }}/rhel6/x86_64/naemon-tools-{{ site.release_version }}-1.rhel6.x86_64.rpm
 ```
 
 **Install Naemon**


### PR DESCRIPTION
Got error without naemon-tools:

```
Error: Package: naemon-1.0.3-1.el6.x86_64 (/naemon-1.0.3-1.rhel6.x86_64)
           Requires: naemon-tools = 1.0.3-1.el6
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
```