### PR TITLE
fix path for log archives in nagios upgrade userguide

### DIFF
--- a/documentation/usersguide/upgrading.md
+++ b/documentation/usersguide/upgrading.md
@@ -71,7 +71,7 @@ Your object configuration files may vary, just copy them into the new conf.d fol
 Copy existing logfiles and archive:
 
 ```bash
-  %> cp -rp /var/log/nagios/archive/*.log /var/log/naemon/archive
+  %> cp -rp /var/log/nagios/archives/*.log /var/log/naemon/archives
   %> cp -rp /var/log/nagios/nagios.log /var/log/naemon/naemon.log
 ```
 


### PR DESCRIPTION
I just tried to follow this guide and ran into two problems. The first one is fairly obvious and fixed with this PR, s/archive/archives/.

The second one i'm not sure about. On my system all the nagios paths mentioned nagios3, not nagios. Might be a good idea to review and see if that should be fixed too.