### PR TITLE
Remove recommendation based on deprecated -s flag

### DIFF
--- a/documentation/usersguide/tuning.md
+++ b/documentation/usersguide/tuning.md
@@ -81,14 +81,10 @@ This is good because it gives you some control over how much load Naemon will
 impose on your monitoring host, but it can also slow things down. If you are
 seeing high latency values (> 10 or 15 seconds) for the majority of your
 service checks (via the <a href="cgis.html#extinfo_cgi">extinfo CGI</a>), you
-are probably starving Naemon of the checks it needs. That's not Naemon's fault
-- its yours. Under ideal conditions, all service checks would have a latency
-of 0, meaning they were executed at the exact time that they were scheduled to
-be executed. However, it is normal for some checks to have small latency
-values. It is recommended taking the minimum number of maximum concurrent
-checks reported when running Naemon with the <b>-s</b> command line argument
-and doubling it. Keep increasing it until the average check latency for your
-services is fairly low.
+are probably starving Naemon of the checks it needs. Under ideal conditions,
+all service checks would have a latency of 0, meaning they were executed at the
+exact time that they were scheduled to be executed. However, it is normal for
+some checks to have small latency values.
 
 
 


### PR DESCRIPTION
The -s flag was deprecated with
https://github.com/naemon/naemon-core/commit/5b9d6e46a40a9fef27df2a906a3cf8bcd9ccc6d and
https://github.com/naemon/naemon-core/commit/51bb37e595bbd1adfecdc4003c2f2075acd67104.

So we should no longer provide tuning recommendations based on this flag.

The calculation which were used and is relevant was the following:

```
minimum_concurrent_checks = ceil((((scheduling_info.total_scheduled_services / scheduling_info.average_service_check_interval)
	                                   + (scheduling_info.total_scheduled_hosts / scheduling_info.average_host_check_interval))
	                                  * 1.4 * scheduling_info.average_service_execution_time));
```

Perhaps we can provide a similar recommendation, but the above calculation is not the easiest to do I guess.