### PR TITLE
Clarify how notifications are sent on ack

### DIFF
--- a/documentation/developer/externalcommands/acknowledge_host_problem.md
+++ b/documentation/developer/externalcommands/acknowledge_host_problem.md
@@ -18,7 +18,7 @@ title: External Command Reference
 
 #### Description:
 
-Allows you to acknowledge the current problem for the specified host. By acknowledging the current problem, future notifications (for the same host state) are disabled. If the 'sticky' option is set to one (1), the acknowledgement will remain until the host returns to an UP state. Otherwise the acknowledgement will automatically be removed when the host changes state. If the 'notify' option is set to one (1), a notification will be sent out to contacts indicating that the current host problem has been acknowledged. If the 'persistent' option is set to one (1), the comment associated with the acknowledgement will survive across restarts of the Naemon process. If not, the comment will be deleted the next time Naemon restarts.
+Allows you to acknowledge the current problem for the specified host. By acknowledging the current problem, future notifications (for the same host state) are disabled. If the 'sticky' option is set to one (1), the acknowledgement will remain until the host returns to an UP state. Otherwise the acknowledgement will automatically be removed when the host changes state. If the 'notify' option is set to one (1), a notification will be sent out to contacts indicating that the current host problem has been acknowledged, this is also true if the host is in a downtime. If the 'persistent' option is set to one (1), the comment associated with the acknowledgement will survive across restarts of the Naemon process. If not, the comment will be deleted the next time Naemon restarts.
 
 #### Shell Script Usage Example:
 

--- a/documentation/developer/externalcommands/acknowledge_svc_problem.md
+++ b/documentation/developer/externalcommands/acknowledge_svc_problem.md
@@ -18,7 +18,7 @@ title: External Command Reference
 
 #### Description:
 
-Allows you to acknowledge the current problem for the specified service. By acknowledging the current problem, future notifications (for the same servicestate) are disabled. If the 'sticky' option is set to one (1), the acknowledgement will remain until the service returns to an OK state. Otherwise the acknowledgement will automatically be removed when the service changes state. If the 'notify' option is set to one (1), a notification will be sent out to contacts indicating that the current service problem has been acknowledged. If the 'persistent' option is set to one (1), the comment associated with the acknowledgement will survive across restarts of the Naemon process. If not, the comment will be deleted the next time Naemon restarts.
+Allows you to acknowledge the current problem for the specified service. By acknowledging the current problem, future notifications (for the same servicestate) are disabled. If the 'sticky' option is set to one (1), the acknowledgement will remain until the service returns to an OK state. Otherwise the acknowledgement will automatically be removed when the service changes state. If the 'notify' option is set to one (1), a notification will be sent out to contacts indicating that the current service problem has been acknowledged, this is also true if the service is in a downtime. If the 'persistent' option is set to one (1), the comment associated with the acknowledgement will survive across restarts of the Naemon process. If not, the comment will be deleted the next time Naemon restarts.
 
 #### Shell Script Usage Example:
 

--- a/documentation/usersguide/downtime.md
+++ b/documentation/usersguide/downtime.md
@@ -30,7 +30,7 @@ When scheduling host or service downtime you have the option of making it "trigg
 
 ### How Scheduled Downtime Affects Notifications
 
-When a host or service is in a period of scheduled downtime, Naemon will not allow normal notifications to be sent out for the host or service.  However, a "DOWNTIMESTART" notification will get sent out for the host or service, which will serve to put any admins on notice that they won't receive upcoming problem alerts.
+When a host or service is in a period of scheduled downtime, Naemon will not allow normal notifications to be sent out for the host or service.  However, a "DOWNTIMESTART" notification will get sent out for the host or service, which will serve to put any admins on notice that they won't receive upcoming problem alerts. Also a notification is sent, even if the object is in a downtime, if an acknowledgement is made with the notify flag set.
 
 When the scheduled downtime is over, Naemon will allow normal notifications to be sent out for the host or service again.  A "DOWNTIMEEND" notification will get sent out notifying admins that the scheduled downtime is over, and they will start receiving normal alerts again.
 


### PR DESCRIPTION
Downtimes does not change behavior of acknowledgement notifications.
That is, even if an object is in a downtime, and an acknowledgment is
made with the `notify` flag enable, a notification will be sent out.

This commit clarifies the behaviour in the documentation.

Signed-off-by: Jacob Hansen <jhansen@op5.com>