### PR TITLE
update contact information

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -21,6 +21,7 @@ jobs:
           sudo apt-get install libencode-perl
           sudo apt-get install libwww-perl
           sudo apt-get install libhtml-lint-perl
+          sudo apt-get install ruby-bundler
           bundle install
 
       - name: run build

--- a/_includes/contacts.md
+++ b/_includes/contacts.md
@@ -1,0 +1,5 @@
+ * Slack channel: [invite link](https://join.slack.com/t/opensourcemonitoring/shared_invite/enQtODE3NTQyMTcxMTg1LWZiMDQyYzBjMDI4OGI2NDJlMzExZWE0NjcyMTg3MWUzMWRjYzIzYzRjODJiZDUyNTFlZDEwNDVlZmI1NmUwMDY)
+ * Mailing lists: [users list](https://www.monitoring-lists.org/list/listinfo/naemon-users/) | [developers list](https://www.monitoring-lists.org/list/listinfo/naemon-dev/)
+ * IRC channels: [#naemon](irc://libera.chat/naemon) and [#naemon-devel](irc://libera.chat/naemon-devel) on libera.chat. ([WebChat](https://kiwiirc.com/nextclient/irc.libera.chat/#naemon))
+ * [Github](https://github.com/naemon) with code and bug tracker.
+ * Twitter: [@naemoncore][twitter]

--- a/community/index.md
+++ b/community/index.md
@@ -4,11 +4,7 @@ title: Get involved
 ---
 We have several of the usual means of contact:
 
- * Slack channel: [invite link](https://join.slack.com/t/opensourcemonitoring/shared_invite/enQtODE3NTQyMTcxMTg1LWZiMDQyYzBjMDI4OGI2NDJlMzExZWE0NjcyMTg3MWUzMWRjYzIzYzRjODJiZDUyNTFlZDEwNDVlZmI1NmUwMDY)
- * Mailing lists: [users list](https://www.monitoring-lists.org/list/listinfo/naemon-users/) | [developers list](https://www.monitoring-lists.org/list/listinfo/naemon-dev/)
- * IRC channels: #naemon and #naemon-devel on freenode
- * [Github](https://github.com/naemon) with code and bug tracker.
- * Twitter: [@naemoncore][twitter]
+{% include contacts.md %}
 
 We need our own [documentation](/documentation) quite desperately. If you want to send us pull requests, or discuss how we should run the documentation project, get in touch.
 

--- a/documentation/usersguide/support.md
+++ b/documentation/usersguide/support.md
@@ -12,6 +12,4 @@ ways to get in touch with other users.
 
 We have several of the usual means of contact:
 
- * Mailing lists: [users list](https://www.monitoring-lists.org/list/listinfo/naemon-users/) | [developers list](https://www.monitoring-lists.org/list/listinfo/naemon-dev/)
- * IRC channels: #naemon and #naemon-devel on Freenode
- * Support Forum: [monitoring-portal.org](http://monitoring-portal.org/wbb/index.php?page=Board&boardID=111) (English/German)
+{% include contacts.md %}


### PR DESCRIPTION
 - freenode irc channels move to libera.chat
 - monitoring portal is eol