### PR TITLE
Remove Google Analytics

### DIFF
--- a/_layouts/raw.html
+++ b/_layouts/raw.html
@@ -60,20 +60,5 @@
       </footer>
     </div> <!-- /container -->
 
-  <!-- Analytics -->
-  <script type="text/javascript">
-    <!--
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', 'UA-49276310-1']);
-    _gaq.push(['_setDomainName', 'naemon.io']);
-    _gaq.push(['_trackPageview']);
-
-    (function() {
-      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-    })();
-    -->
-  </script>
   </body>
 </html>


### PR DESCRIPTION
It has no use, and better for privacy/GDPR.

Signed-off-by: Jacob Hansen <jhansen@itrsgroup.com>