### PR TITLE
Update Standard Macros in Naemon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
+
+gem "webrick", "~> 1.7"

--- a/_layouts/raw.html
+++ b/_layouts/raw.html
@@ -21,8 +21,16 @@
 
     <script src="/js/jquery-1.10.2.min.js"></script>
     <script src="/js/bootstrap.min.3.1.0.js"></script>
+
     {{ page.extra_head }}
+
+    {% if layout.extra_css %}
+    <!-- Layout CSS -->
+    <link rel="stylesheet" href="/css/{{ layout.extra_css }}">
+    {% endif %}
+    
     {% if page.extra_css %}
+    <!-- Page CSS -->
     <link rel="stylesheet" href="/css/{{ page.extra_css }}">
     {% endif %}
   </head>

--- a/css/doc.css
+++ b/css/doc.css
@@ -1,3 +1,5 @@
+/* All this css was never loaded, so i commented this out for historical reasons */
+/*
 TABLE TH {
     border: 0;
 }
@@ -26,4 +28,16 @@ TABLE.livestatus_table TH:first-child {
 }
 TABLE.livestatus_table TH:last-child {
     width: 500px;
+}
+*/
+
+.MacroYes {
+    background-color: #dff0d8;
+}
+
+.th-sticky {
+    position: sticky;
+    top: 50px;
+    background-clip: padding-box; /* show border */
+    background-color: #ffffff;
 }

--- a/documentation/usersguide/macrolist.md
+++ b/documentation/usersguide/macrolist.md
@@ -48,15 +48,15 @@ macros consist of all uppercase characters and are enclosed in <b>$</b> characte
 <div align="center">
 <table border="1" cellspacing="0" cellpadding="5">
 <tr class="Macros">
-<th class="Macros">Macro Name</th>
-<th class="Macros">Service Checks</th>
-<th class="Macros">Service Notifications</th>
-<th class="Macros">Host Checks</th>
-<th class="Macros">Host Notifications</th>
-<th class="Macros">Service Event Handlers and <a href="configmain.html#ocsp_command">OCSP</a></th>
-<th class="Macros">Host Event Handlers and <a href="configmain.html#ochp_command">OCHP</a></th>
-<th class="Macros">Service Perf Data</th>
-<th class="Macros">Host Perf Data</th>
+<th class="Macros th-sticky">Macro Name</th>
+<th class="Macros th-sticky">Service Checks</th>
+<th class="Macros th-sticky">Service Notifications</th>
+<th class="Macros th-sticky">Host Checks</th>
+<th class="Macros th-sticky">Host Notifications</th>
+<th class="Macros th-sticky">Service Event Handlers and <a href="configmain.html#ocsp_command">OCSP</a></th>
+<th class="Macros th-sticky">Host Event Handlers and <a href="configmain.html#ochp_command">OCHP</a></th>
+<th class="Macros th-sticky">Service Perf Data</th>
+<th class="Macros th-sticky">Host Perf Data</th>
 </tr>
 <tr>
 <td colspan='9' class='MacroType'>Host Macros: <a href="#note3"><sup>3</sup></a></td>


### PR DESCRIPTION
- I have re-enabled the option to load layout and page specific css files. 
- "Yes" macros are now highlighted in green color.
- The table header is now sticky and stays on top of the screen while scrolling.
- Add `webrick` to the  `Gemfile` (was missing and required on my Windows System)

See it in action:

![naemon_macros](https://user-images.githubusercontent.com/9019992/178461748-a0d70296-25f6-4bb0-bc2b-5e0d6a937d29.png)
