### PR TITLE
replace apt-key with signed-by entries

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -89,19 +89,19 @@ This list is not synchronized with the build server, so there might be more repo
 ##### Install GPG key
 First you import the GPG key.
 ```
-curl -s "https://build.opensuse.org/projects/home:naemon/public_key" | sudo apt-key add -
+curl -s -o /etc/apt/trusted.gpg.d/naemon.asc "https://build.opensuse.org/projects/home:naemon/public_key"
 
 ```
 
 ##### Ubuntu
 ```
-echo "deb http://download.opensuse.org/repositories/home:/naemon/xUbuntu_$(lsb_release -rs)/ ./" >> /etc/apt/sources.list.d/naemon-stable.list
+echo "deb [signed-by=/etc/apt/trusted.gpg.d/naemon.asc] http://download.opensuse.org/repositories/home:/naemon/xUbuntu_$(lsb_release -rs)/ ./" >> /etc/apt/sources.list.d/naemon-stable.list
 apt-get update
 ```
 
 ##### Debian
 ```
-echo "deb http://download.opensuse.org/repositories/home:/naemon/Debian_$(lsb_release -rs)/ ./" >> /etc/apt/sources.list.d/naemon-stable.list
+echo "deb [signed-by=/etc/apt/trusted.gpg.d/naemon.asc] http://download.opensuse.org/repositories/home:/naemon/Debian_$(lsb_release -rs)/ ./" >> /etc/apt/sources.list.d/naemon-stable.list
 apt-get update
 ```
 


### PR DESCRIPTION
Usage of apt-key is deprecated, and it will be removed past Debian 11 and Ubuntu 22.04 (see apt-key(8)). Replace references in index with signed-by entries.