### PR TITLE
use Liquid function markdownify to simplify markup

### DIFF
--- a/documentation/faq/usersguide-guidelines.md
+++ b/documentation/faq/usersguide-guidelines.md
@@ -63,6 +63,12 @@ informational, warning or danger. See code snippets below
 &#123;&#123; site.warn &#125;&#125;It's not possible to use Markdown inside a html block...&#123;&#123; site.end &#125;&#125;
 </pre>
 
+#### Note
+
+{{ site.note }}{{ "You can use the Liquid filter `markdownify` to use markdown syntax inside html blocks." | markdownify }}{{ site.end }}
+<pre>
+&#123;&#123; site.note &#125;&#125;&#123;&#123; &quot;You can use the Liquid filter `markdownify` ...&quot; | markdownify &#125;&#125;...&#123;&#123; site.end &#125;&#125;
+</pre>
 
 #### Danger
 

--- a/documentation/usersguide/pluginapi.md
+++ b/documentation/usersguide/pluginapi.md
@@ -37,7 +37,7 @@ Naemon determines the status of a host or service by evaluating the return code 
 | 2                  | `CRITICAL`    | `DOWN`/`UNREACHABLE`         |
 | 3                  | `UNKNOWN`     | `DOWN`/`UNREACHABLE`         |
 
-{{ site.note }}If the [use_aggressive_host_checking](configmain.html#use_aggressive_host_checking) option is enabled, return codes of 1 will result in a host state of `DOWN` or `UNREACHABLE`.  Otherwise return codes of 1 will result in a host state of `UP`.  The process by which Naemon determines whether or not a host is `DOWN` or `UNREACHABLE` is discussed [here](networkreachability.html).{{ site.end }}
+{{ site.note }}{{ "If the [use_aggressive_host_checking](configmain.html#use_aggressive_host_checking) option is enabled, return codes of 1 will result in a host state of `DOWN` or `UNREACHABLE`.  Otherwise return codes of 1 will result in a host state of `UP`.  The process by which Naemon determines whether or not a host is `DOWN` or `UNREACHABLE` is discussed [here](networkreachability.html)." | markdownify}}{{ site.end }}
 
 ### Plugin Output Spec
 
@@ -79,11 +79,7 @@ A plugin can return optional performance data for use by external applications. 
 <div style="display: inline; color: red;">DISK OK - free space: / 3326 MB (56%);</div><div style="display: inline;">&nbsp;|&nbsp;</div><div style="display: inline; color: orange;">/=2643MB;5948;5958;0;5968</div>
 </div>
 
-<div style="float: left;">If this plugin was used to perform a service check, the</div>
-<div style="display: inline; color: red;">&nbsp;red&nbsp;</div>
-<div style="display: inline;">portion of output (left of the pipe separator) will be stored in the [`$SERVICEOUTPUT$`](macrolist.html#serviceoutput) macro and the</div>
-<div style="color: orange; display: inline;">&nbsp;orange&nbsp;</div>
-<div style="display: inline;">portion of output (right of the pipe separator) will be stored in the [`$SERVICEPERFDATA$`](macrolist.html#serviceperfdata) macro.</div>
+If this plugin was used to perform a service check, the <font color="red">red</font> portion of output (left of the pipe separator) will be stored in the [`$SERVICEOUTPUT$`](macrolist.html#serviceoutput) macro and the <font color="#FFA500">orange</font> portion of output (right of the pipe separator) will be stored in the [`$SERVICEPERFDATA$`](macrolist.html#serviceperfdata) macro.
 
 **Case 3: Multiple lines of output (text and perfdata)**
 

--- a/documentation/usersguide/pluginapi.md
+++ b/documentation/usersguide/pluginapi.md
@@ -87,7 +87,7 @@ A plugin optionally return multiple lines of both text output and perfdata, like
 
 <div style="padding: 0 0 0 25px;">
 <font color="red">DISK OK - free space: / 3326 MB (56%);</font>&nbsp;|&nbsp;<font color="#FFA500">/=2643MB;5948;5958;0;5968</font><br>
-<font color="#00A500">/ 15272 MB (77%);</font><br>
+<font color="#00A500">/ 3326 MB (56%);</font><br>
 <font color="#00A500">/boot 68 MB (69%);</font><br>
 <font color="#00A500">/home 69357 MB (27%);</font><br>
 <font color="#00A500">/var/log 819 MB (84%);</font>&nbsp;|&nbsp;<font color="#FFA500">/boot=68MB;88;93;0;98</font><br>
@@ -105,7 +105,7 @@ The final contents of each macro are listed below:
 |-------|-----------------------------------|
 | `$SERVICEOUTPUT$`     | <font color="red">DISK OK - free space: / 3326 MB (56%);</font> |
 | `$SERVICEPERFDATA$`   | <font color="#FFA500">/=2643MB;5948;5958;0;5968 /boot=68MB;88;93;0;98 /home=69357MB;253404;253409;0;253414 /var/log=818MB;970;975;0;980</font> |
-| `$LONGSERVICEOUTPUT$` | <font color="#00A500">/ 15272 MB (77%);\n/boot 68 MB (69%);\n/var/log 819 MB (84%);</font> |
+| `$LONGSERVICEOUTPUT$` | <font color="#00A500">/ 3326 MB (56%);\n/boot 68 MB (69%);\n/var/log 819 MB (84%);</font> |
 
 With regards to multiple lines of output, you have the following options for returning performance data:
 


### PR DESCRIPTION
another day, another patch to the pluginapi.md.  I didn't spin up Jekyll, so I had not spotted the gotcha with markdown inside HTML.  found and documented a workaround.  In the second snippet, `markdownify` could not be used since it always encloses the result in `<p></p>`, but all those `<div>` seems needlessly complex anyway.
