### PR TITLE
Update external commands template

### DIFF
--- a/src/documentation/developer/externalcommands/_command.tpl
+++ b/src/documentation/developer/externalcommands/_command.tpl
@@ -28,7 +28,5 @@ const command = {% cmd %};
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/acknowledge_host_problem.md
+++ b/src/documentation/developer/externalcommands/acknowledge_host_problem.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"sticky","ty
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/acknowledge_host_problem_expire.md
+++ b/src/documentation/developer/externalcommands/acknowledge_host_problem_expire.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"sticky","ty
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/acknowledge_svc_problem.md
+++ b/src/documentation/developer/externalcommands/acknowledge_svc_problem.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"sticky","t
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/acknowledge_svc_problem_expire.md
+++ b/src/documentation/developer/externalcommands/acknowledge_svc_problem_expire.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"sticky","t
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/add_host_comment.md
+++ b/src/documentation/developer/externalcommands/add_host_comment.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"persistent"
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/add_svc_comment.md
+++ b/src/documentation/developer/externalcommands/add_svc_comment.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"persistent
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_contact_host_notification_timeperiod.md
+++ b/src/documentation/developer/externalcommands/change_contact_host_notification_timeperiod.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"notif
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_contact_modattr.md
+++ b/src/documentation/developer/externalcommands/change_contact_modattr.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"value
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_contact_modhattr.md
+++ b/src/documentation/developer/externalcommands/change_contact_modhattr.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"value
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_contact_modsattr.md
+++ b/src/documentation/developer/externalcommands/change_contact_modsattr.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"value
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_contact_svc_notification_timeperiod.md
+++ b/src/documentation/developer/externalcommands/change_contact_svc_notification_timeperiod.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"notif
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_custom_contact_var.md
+++ b/src/documentation/developer/externalcommands/change_custom_contact_var.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"varna
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_custom_host_var.md
+++ b/src/documentation/developer/externalcommands/change_custom_host_var.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"varname","t
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_custom_svc_var.md
+++ b/src/documentation/developer/externalcommands/change_custom_svc_var.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"varname","
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_global_host_event_handler.md
+++ b/src/documentation/developer/externalcommands/change_global_host_event_handler.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"event_handler_command","type":"str"}],"name":"
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_global_svc_event_handler.md
+++ b/src/documentation/developer/externalcommands/change_global_svc_event_handler.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"event_handler_command","type":"str"}],"name":"
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_host_check_command.md
+++ b/src/documentation/developer/externalcommands/change_host_check_command.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_comma
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_host_check_timeperiod.md
+++ b/src/documentation/developer/externalcommands/change_host_check_timeperiod.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_timep
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_host_event_handler.md
+++ b/src/documentation/developer/externalcommands/change_host_event_handler.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"event_handl
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_host_modattr.md
+++ b/src/documentation/developer/externalcommands/change_host_modattr.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"value","typ
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_host_notification_timeperiod.md
+++ b/src/documentation/developer/externalcommands/change_host_notification_timeperiod.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"notificatio
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_max_host_check_attempts.md
+++ b/src/documentation/developer/externalcommands/change_max_host_check_attempts.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_attem
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_max_svc_check_attempts.md
+++ b/src/documentation/developer/externalcommands/change_max_svc_check_attempts.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"check_atte
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_normal_host_check_interval.md
+++ b/src/documentation/developer/externalcommands/change_normal_host_check_interval.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_inter
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_normal_svc_check_interval.md
+++ b/src/documentation/developer/externalcommands/change_normal_svc_check_interval.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"check_inte
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_retry_host_check_interval.md
+++ b/src/documentation/developer/externalcommands/change_retry_host_check_interval.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_inter
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_retry_svc_check_interval.md
+++ b/src/documentation/developer/externalcommands/change_retry_svc_check_interval.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"check_inte
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_svc_check_command.md
+++ b/src/documentation/developer/externalcommands/change_svc_check_command.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"check_comm
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_svc_check_timeperiod.md
+++ b/src/documentation/developer/externalcommands/change_svc_check_timeperiod.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"check_time
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_svc_event_handler.md
+++ b/src/documentation/developer/externalcommands/change_svc_event_handler.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"event_hand
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_svc_modattr.md
+++ b/src/documentation/developer/externalcommands/change_svc_modattr.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"value","ty
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_svc_notification_timeperiod.md
+++ b/src/documentation/developer/externalcommands/change_svc_notification_timeperiod.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"notificati
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_all_host_comments.md
+++ b/src/documentation/developer/externalcommands/del_all_host_comments.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DEL_ALL_HOS
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_all_svc_comments.md
+++ b/src/documentation/developer/externalcommands/del_all_svc_comments.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"DEL_ALL_SV
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_downtime_by_host_name.md
+++ b/src/documentation/developer/externalcommands/del_downtime_by_host_name.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"DEL_DOWNTIME_BY_HOST_NAME","description":"Thi
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_downtime_by_hostgroup_name.md
+++ b/src/documentation/developer/externalcommands/del_downtime_by_hostgroup_name.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostname","type":"STRING"},{"name":"service_de
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_downtime_by_start_time_comment.md
+++ b/src/documentation/developer/externalcommands/del_downtime_by_start_time_comment.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"HOSTGROUP"},{"name":"h
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_host_comment.md
+++ b/src/documentation/developer/externalcommands/del_host_comment.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"comment_id","type":"ulong"}],"name":"DEL_HOST_
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_host_downtime.md
+++ b/src/documentation/developer/externalcommands/del_host_downtime.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"downtime_id","type":"ulong"}],"name":"DEL_HOST
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_svc_comment.md
+++ b/src/documentation/developer/externalcommands/del_svc_comment.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"comment_id","type":"ulong"}],"name":"DEL_SVC_C
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_svc_downtime.md
+++ b/src/documentation/developer/externalcommands/del_svc_downtime.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"downtime_id","type":"ulong"}],"name":"DEL_SVC_
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/delay_host_notification.md
+++ b/src/documentation/developer/externalcommands/delay_host_notification.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"notificatio
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/delay_svc_notification.md
+++ b/src/documentation/developer/externalcommands/delay_svc_notification.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"notificati
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_all_notifications_beyond_host.md
+++ b/src/documentation/developer/externalcommands/disable_all_notifications_beyond_host.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_ALL
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_contact_host_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_contact_host_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"DISAB
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_contact_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_contact_svc_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"DISAB
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_contactgroup_host_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_contactgroup_host_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_contactgroup_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_contactgroup_svc_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_event_handlers.md
+++ b/src/documentation/developer/externalcommands/disable_event_handlers.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"DISABLE_EVENT_HANDLERS","description":"Disabl
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_flap_detection.md
+++ b/src/documentation/developer/externalcommands/disable_flap_detection.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"DISABLE_FLAP_DETECTION","description":"Disabl
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_and_child_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_host_and_child_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOS
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_check.md
+++ b/src/documentation/developer/externalcommands/disable_host_check.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOS
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_event_handler.md
+++ b/src/documentation/developer/externalcommands/disable_host_event_handler.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOS
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_flap_detection.md
+++ b/src/documentation/developer/externalcommands/disable_host_flap_detection.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOS
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_freshness_checks.md
+++ b/src/documentation/developer/externalcommands/disable_host_freshness_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"DISABLE_HOST_FRESHNESS_CHECKS","description":
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_host_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOS
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_svc_checks.md
+++ b/src/documentation/developer/externalcommands/disable_host_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOS
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_host_svc_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOS
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_hostgroup_host_checks.md
+++ b/src/documentation/developer/externalcommands/disable_hostgroup_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"D
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_hostgroup_host_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_hostgroup_host_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"D
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_hostgroup_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/disable_hostgroup_passive_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"D
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_hostgroup_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/disable_hostgroup_passive_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"D
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_hostgroup_svc_checks.md
+++ b/src/documentation/developer/externalcommands/disable_hostgroup_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"D
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_hostgroup_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_hostgroup_svc_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"D
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"DISABLE_NOTIFICATIONS","description":"Disable
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/disable_passive_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_PAS
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/disable_passive_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_PA
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_performance_data.md
+++ b/src/documentation/developer/externalcommands/disable_performance_data.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"DISABLE_PERFORMANCE_DATA","description":"Disa
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_service_freshness_checks.md
+++ b/src/documentation/developer/externalcommands/disable_service_freshness_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"DISABLE_SERVICE_FRESHNESS_CHECKS","descriptio
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_servicegroup_host_checks.md
+++ b/src/documentation/developer/externalcommands/disable_servicegroup_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_servicegroup_host_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_servicegroup_host_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_servicegroup_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/disable_servicegroup_passive_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_servicegroup_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/disable_servicegroup_passive_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_servicegroup_svc_checks.md
+++ b/src/documentation/developer/externalcommands/disable_servicegroup_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_servicegroup_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_servicegroup_svc_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_svc_check.md
+++ b/src/documentation/developer/externalcommands/disable_svc_check.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_SV
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_svc_event_handler.md
+++ b/src/documentation/developer/externalcommands/disable_svc_event_handler.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_SV
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_svc_flap_detection.md
+++ b/src/documentation/developer/externalcommands/disable_svc_flap_detection.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_SV
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_svc_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_SV
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_all_notifications_beyond_host.md
+++ b/src/documentation/developer/externalcommands/enable_all_notifications_beyond_host.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_ALL_
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_contact_host_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_contact_host_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"ENABL
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_contact_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_contact_svc_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"ENABL
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_contactgroup_host_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_contactgroup_host_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_contactgroup_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_contactgroup_svc_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_event_handlers.md
+++ b/src/documentation/developer/externalcommands/enable_event_handlers.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"downtime_start_time","type":"TIMESTAMP"},{"nam
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_flap_detection.md
+++ b/src/documentation/developer/externalcommands/enable_flap_detection.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"ENABLE_FLAP_DETECTION","description":"Enables
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_and_child_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_host_and_child_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_check.md
+++ b/src/documentation/developer/externalcommands/enable_host_check.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_event_handler.md
+++ b/src/documentation/developer/externalcommands/enable_host_event_handler.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_flap_detection.md
+++ b/src/documentation/developer/externalcommands/enable_host_flap_detection.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_freshness_checks.md
+++ b/src/documentation/developer/externalcommands/enable_host_freshness_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"ENABLE_HOST_FRESHNESS_CHECKS","description":"
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_host_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_svc_checks.md
+++ b/src/documentation/developer/externalcommands/enable_host_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_host_svc_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_hostgroup_host_checks.md
+++ b/src/documentation/developer/externalcommands/enable_hostgroup_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"E
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_hostgroup_host_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_hostgroup_host_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"E
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_hostgroup_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/enable_hostgroup_passive_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"E
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_hostgroup_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/enable_hostgroup_passive_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"E
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_hostgroup_svc_checks.md
+++ b/src/documentation/developer/externalcommands/enable_hostgroup_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"E
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_hostgroup_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_hostgroup_svc_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"E
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"ENABLE_NOTIFICATIONS","description":"Enables 
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/enable_passive_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_PASS
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/enable_passive_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_PAS
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_performance_data.md
+++ b/src/documentation/developer/externalcommands/enable_performance_data.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"ENABLE_PERFORMANCE_DATA","description":"Enabl
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_service_freshness_checks.md
+++ b/src/documentation/developer/externalcommands/enable_service_freshness_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"ENABLE_SERVICE_FRESHNESS_CHECKS","description
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_servicegroup_host_checks.md
+++ b/src/documentation/developer/externalcommands/enable_servicegroup_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_servicegroup_host_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_servicegroup_host_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_servicegroup_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/enable_servicegroup_passive_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_servicegroup_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/enable_servicegroup_passive_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_servicegroup_svc_checks.md
+++ b/src/documentation/developer/externalcommands/enable_servicegroup_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_servicegroup_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_servicegroup_svc_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_svc_check.md
+++ b/src/documentation/developer/externalcommands/enable_svc_check.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_SVC
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_svc_event_handler.md
+++ b/src/documentation/developer/externalcommands/enable_svc_event_handler.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_SVC
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_svc_flap_detection.md
+++ b/src/documentation/developer/externalcommands/enable_svc_flap_detection.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_SVC
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_svc_notifications.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_SVC
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/log.md
+++ b/src/documentation/developer/externalcommands/log.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"LOG","description":"Adds custom entry to the 
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/process_file.md
+++ b/src/documentation/developer/externalcommands/process_file.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"file_name","type":"str"},{"name":"delete","typ
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/process_host_check_result.md
+++ b/src/documentation/developer/externalcommands/process_host_check_result.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"status_code
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/process_service_check_result.md
+++ b/src/documentation/developer/externalcommands/process_service_check_result.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"status_cod
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/read_state_information.md
+++ b/src/documentation/developer/externalcommands/read_state_information.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"READ_STATE_INFORMATION","description":"Causes
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/remove_host_acknowledgement.md
+++ b/src/documentation/developer/externalcommands/remove_host_acknowledgement.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"REMOVE_HOST
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/remove_svc_acknowledgement.md
+++ b/src/documentation/developer/externalcommands/remove_svc_acknowledgement.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"REMOVE_SVC
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/restart_process.md
+++ b/src/documentation/developer/externalcommands/restart_process.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"RESTART_PROCESS","description":"Restarts the 
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/restart_program.md
+++ b/src/documentation/developer/externalcommands/restart_program.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"RESTART_PROGRAM","description":"Restarts the 
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/save_state_information.md
+++ b/src/documentation/developer/externalcommands/save_state_information.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"SAVE_STATE_INFORMATION","description":"Causes
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_and_propagate_host_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_and_propagate_host_downtime.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time"
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_and_propagate_triggered_host_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_and_propagate_triggered_host_downtime.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time"
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_forced_host_check.md
+++ b/src/documentation/developer/externalcommands/schedule_forced_host_check.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time"
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_forced_host_svc_checks.md
+++ b/src/documentation/developer/externalcommands/schedule_forced_host_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time"
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_forced_svc_check.md
+++ b/src/documentation/developer/externalcommands/schedule_forced_svc_check.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"check_time
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_host_check.md
+++ b/src/documentation/developer/externalcommands/schedule_host_check.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time"
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_host_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_host_downtime.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time"
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_host_svc_checks.md
+++ b/src/documentation/developer/externalcommands/schedule_host_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time"
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_host_svc_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_host_svc_downtime.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time"
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_hostgroup_host_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_hostgroup_host_downtime.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"},{"name":"s
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_hostgroup_svc_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_hostgroup_svc_downtime.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"},{"name":"s
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_servicegroup_host_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_servicegroup_host_downtime.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"},{"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_servicegroup_svc_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_servicegroup_svc_downtime.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"},{"na
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_svc_check.md
+++ b/src/documentation/developer/externalcommands/schedule_svc_check.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"check_time
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_svc_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_svc_downtime.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"start_time
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/send_custom_host_notification.md
+++ b/src/documentation/developer/externalcommands/send_custom_host_notification.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"options","t
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/send_custom_svc_notification.md
+++ b/src/documentation/developer/externalcommands/send_custom_svc_notification.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"options","
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/set_host_notification_number.md
+++ b/src/documentation/developer/externalcommands/set_host_notification_number.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"notificatio
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/set_svc_notification_number.md
+++ b/src/documentation/developer/externalcommands/set_svc_notification_number.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"notificati
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/shutdown_process.md
+++ b/src/documentation/developer/externalcommands/shutdown_process.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"SHUTDOWN_PROCESS","description":"Shuts down t
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/shutdown_program.md
+++ b/src/documentation/developer/externalcommands/shutdown_program.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"SHUTDOWN_PROGRAM","description":"Shuts down t
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_accepting_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/start_accepting_passive_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"START_ACCEPTING_PASSIVE_HOST_CHECKS","descrip
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_accepting_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/start_accepting_passive_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"START_ACCEPTING_PASSIVE_SVC_CHECKS","descript
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_executing_host_checks.md
+++ b/src/documentation/developer/externalcommands/start_executing_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"START_EXECUTING_HOST_CHECKS","description":"E
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_executing_svc_checks.md
+++ b/src/documentation/developer/externalcommands/start_executing_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"START_EXECUTING_SVC_CHECKS","description":"En
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_obsessing_over_host.md
+++ b/src/documentation/developer/externalcommands/start_obsessing_over_host.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"START_OBSES
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_obsessing_over_host_checks.md
+++ b/src/documentation/developer/externalcommands/start_obsessing_over_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"START_OBSESSING_OVER_HOST_CHECKS","descriptio
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_obsessing_over_svc.md
+++ b/src/documentation/developer/externalcommands/start_obsessing_over_svc.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"START_OBSE
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_obsessing_over_svc_checks.md
+++ b/src/documentation/developer/externalcommands/start_obsessing_over_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"START_OBSESSING_OVER_SVC_CHECKS","description
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_accepting_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/stop_accepting_passive_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"STOP_ACCEPTING_PASSIVE_HOST_CHECKS","descript
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_accepting_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/stop_accepting_passive_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"STOP_ACCEPTING_PASSIVE_SVC_CHECKS","descripti
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_executing_host_checks.md
+++ b/src/documentation/developer/externalcommands/stop_executing_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"STOP_EXECUTING_HOST_CHECKS","description":"Di
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_executing_svc_checks.md
+++ b/src/documentation/developer/externalcommands/stop_executing_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"STOP_EXECUTING_SVC_CHECKS","description":"Dis
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_obsessing_over_host.md
+++ b/src/documentation/developer/externalcommands/stop_obsessing_over_host.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"STOP_OBSESS
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_obsessing_over_host_checks.md
+++ b/src/documentation/developer/externalcommands/stop_obsessing_over_host_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"STOP_OBSESSING_OVER_HOST_CHECKS","description
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_obsessing_over_svc.md
+++ b/src/documentation/developer/externalcommands/stop_obsessing_over_svc.md
@@ -28,7 +28,5 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"STOP_OBSES
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_obsessing_over_svc_checks.md
+++ b/src/documentation/developer/externalcommands/stop_obsessing_over_svc_checks.md
@@ -28,7 +28,5 @@ const command = {"args":[],"name":"STOP_OBSESSING_OVER_SVC_CHECKS","description"
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
 
-printf "[%%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
-    `date +%%s` \
-    > /var/lib/naemon/naemon.cmd
+printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" `date +%s` > /var/lib/naemon/naemon.cmd
 ```


### PR DESCRIPTION
Removes one Percent Symbols from the commands. (`[%%lu]` => `[%lu]`)
I also had to remove the line breaks to make to "Copy Code" button also copy the ">" char