### PR TITLE
Prefix all external command examples for services with "host_name"

### DIFF
--- a/src/documentation/developer/externalcommands/_command.tpl
+++ b/src/documentation/developer/externalcommands/_command.tpl
@@ -28,7 +28,7 @@ const command = {% cmd %};
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/acknowledge_host_problem.md
+++ b/src/documentation/developer/externalcommands/acknowledge_host_problem.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"sticky","type":"int"},{"name":"notify","type":"bool"},{"name":"persistent","type":"bool"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"ACKNOWLEDGE_HOST_PROBLEM","description":"Allows you to acknowledge the current problem for the specified host. By acknowledging the current problem, future notifications (for the same host state) are disabled. If the 'sticky' option is set to one (1), the acknowledgement will remain until the host returns to an UP state. Otherwise the acknowledgement will automatically be removed when the host changes state. If the 'notify' option is set to one (1), a notification will be sent out to contacts indicating that the current host problem has been acknowledged. If the 'persistent' option is set to one (1), the comment associated with the acknowledgement will remain once the acknowledgement is removed. If not, the comment will be deleted when the acknowledgement is removed.","classes":["host","comment"],"argsStr":";host_name;sticky;notify;persistent;author;comment","exampleArgStr":";host1;1;1;1;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"sticky","type":"int"},{"name":"notify","type":"bool"},{"name":"persistent","type":"bool"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"ACKNOWLEDGE_HOST_PROBLEM","description":"Allows you to acknowledge the current problem for the specified host. By acknowledging the current problem, future notifications (for the same host state) are disabled. If the 'sticky' option is set to one (1), the acknowledgement will remain until the host returns to an UP state. Otherwise the acknowledgement will automatically be removed when the host changes state. If the 'notify' option is set to one (1), a notification will be sent out to contacts indicating that the current host problem has been acknowledged. If the 'persistent' option is set to one (1), the comment associated with the acknowledgement will remain once the acknowledgement is removed. If not, the comment will be deleted when the acknowledgement is removed.","classes":["host","comment"],"commandType":4,"argsStr":";host_name;sticky;notify;persistent;author;comment","exampleArgStr":";host1;1;1;1;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"sticky","ty
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/acknowledge_host_problem_expire.md
+++ b/src/documentation/developer/externalcommands/acknowledge_host_problem_expire.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"sticky","type":"int"},{"name":"notify","type":"bool"},{"name":"persistent","type":"bool"},{"name":"end_time","type":"timestamp"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"ACKNOWLEDGE_HOST_PROBLEM_EXPIRE","description":"Allows you to acknowledge the current problem for the specified host for a limitied time. By acknowledging the current problem, future notifications (for the same host state) are disabled. The 'end_time' option determines the time after which the acknowledgement is cleared automatically. If the 'sticky' option is set to one (1), the acknowledgement will remain until the host returns to an UP state. Otherwise the acknowledgement will automatically be removed when the host changes state. If the 'notify' option is set to one (1), a notification will be sent out to contacts indicating that the current host problem has been acknowledged. If the 'persistent' option is set to one (1), the comment associated with the acknowledgement will remain once the acknowledgement is removed. If not, the comment will be deleted when the acknowledgement is removed.","classes":["host","comment"],"argsStr":";host_name;sticky;notify;persistent;end_time;author;comment","exampleArgStr":";host1;1;1;1;1478638441;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"sticky","type":"int"},{"name":"notify","type":"bool"},{"name":"persistent","type":"bool"},{"name":"end_time","type":"timestamp"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"ACKNOWLEDGE_HOST_PROBLEM_EXPIRE","description":"Allows you to acknowledge the current problem for the specified host for a limitied time. By acknowledging the current problem, future notifications (for the same host state) are disabled. The 'end_time' option determines the time after which the acknowledgement is cleared automatically. If the 'sticky' option is set to one (1), the acknowledgement will remain until the host returns to an UP state. Otherwise the acknowledgement will automatically be removed when the host changes state. If the 'notify' option is set to one (1), a notification will be sent out to contacts indicating that the current host problem has been acknowledged. If the 'persistent' option is set to one (1), the comment associated with the acknowledgement will remain once the acknowledgement is removed. If not, the comment will be deleted when the acknowledgement is removed.","classes":["host","comment"],"commandType":4,"argsStr":";host_name;sticky;notify;persistent;end_time;author;comment","exampleArgStr":";host1;1;1;1;1478638441;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"sticky","ty
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/acknowledge_svc_problem.md
+++ b/src/documentation/developer/externalcommands/acknowledge_svc_problem.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"sticky","type":"int"},{"name":"notify","type":"bool"},{"name":"persistent","type":"bool"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"ACKNOWLEDGE_SVC_PROBLEM","description":"Allows you to acknowledge the current problem for the specified service. By acknowledging the current problem, future notifications (for the same servicestate) are disabled. If the 'sticky' option is set to one (1), the acknowledgement will remain until the service returns to an OK state. Otherwise the acknowledgement will automatically be removed when the service changes state. If the 'notify' option is set to one (1), a notification will be sent out to contacts indicating that the current service problem has been acknowledged. If the 'persistent' option is set to one (1), the comment associated with the acknowledgement will remain once the acknowledgement is removed. If not, the comment will be deleted when the acknowledgement is removed.","classes":["service","comment"],"argsStr":";service;sticky;notify;persistent;author;comment","exampleArgStr":";service1;1;1;1;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"sticky","type":"int"},{"name":"notify","type":"bool"},{"name":"persistent","type":"bool"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"ACKNOWLEDGE_SVC_PROBLEM","description":"Allows you to acknowledge the current problem for the specified service. By acknowledging the current problem, future notifications (for the same servicestate) are disabled. If the 'sticky' option is set to one (1), the acknowledgement will remain until the service returns to an OK state. Otherwise the acknowledgement will automatically be removed when the service changes state. If the 'notify' option is set to one (1), a notification will be sent out to contacts indicating that the current service problem has been acknowledged. If the 'persistent' option is set to one (1), the comment associated with the acknowledgement will remain once the acknowledgement is removed. If not, the comment will be deleted when the acknowledgement is removed.","classes":["service","comment"],"commandType":6,"argsStr":";host_name;service_description;sticky;notify;persistent;author;comment","exampleArgStr":";host1;service1;1;1;1;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"sticky","t
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/acknowledge_svc_problem_expire.md
+++ b/src/documentation/developer/externalcommands/acknowledge_svc_problem_expire.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"sticky","type":"int"},{"name":"notify","type":"bool"},{"name":"persistent","type":"bool"},{"name":"end_time","type":"timestamp"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"ACKNOWLEDGE_SVC_PROBLEM_EXPIRE","description":"Allows you to acknowledge the current problem for the specified service. By acknowledging the current problem, future notifications (for the same servicestate) are disabled. The 'end_time' option determines the time after which the acknowledgement is cleared automatically. If the 'sticky' option is set to one (1), the acknowledgement will remain until the service returns to an OK state. Otherwise the acknowledgement will automatically be removed when the service changes state. If the 'notify' option is set to one (1), a notification will be sent out to contacts indicating that the current service problem has been acknowledged. If the 'persistent' option is set to one (1), the comment associated with the acknowledgement will remain once the acknowledgement is removed. If not, the comment will be deleted when the acknowledgement is removed.","classes":["service","comment"],"argsStr":";service;sticky;notify;persistent;end_time;author;comment","exampleArgStr":";service1;1;1;1;1478638441;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"sticky","type":"int"},{"name":"notify","type":"bool"},{"name":"persistent","type":"bool"},{"name":"end_time","type":"timestamp"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"ACKNOWLEDGE_SVC_PROBLEM_EXPIRE","description":"Allows you to acknowledge the current problem for the specified service. By acknowledging the current problem, future notifications (for the same servicestate) are disabled. The 'end_time' option determines the time after which the acknowledgement is cleared automatically. If the 'sticky' option is set to one (1), the acknowledgement will remain until the service returns to an OK state. Otherwise the acknowledgement will automatically be removed when the service changes state. If the 'notify' option is set to one (1), a notification will be sent out to contacts indicating that the current service problem has been acknowledged. If the 'persistent' option is set to one (1), the comment associated with the acknowledgement will remain once the acknowledgement is removed. If not, the comment will be deleted when the acknowledgement is removed.","classes":["service","comment"],"commandType":6,"argsStr":";host_name;service_description;sticky;notify;persistent;end_time;author;comment","exampleArgStr":";host1;service1;1;1;1;1478638441;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"sticky","t
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/add_host_comment.md
+++ b/src/documentation/developer/externalcommands/add_host_comment.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"persistent","type":"bool"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"ADD_HOST_COMMENT","description":"This command is used to add a comment for the specified host.  If you work with other administrators, you may find it useful to share information about a host that is having problems if more than one of you may be working on it.  If you do not check the 'persistent' option, the comment will be automatically be deleted at the the next program restarted.","classes":["host","comment"],"argsStr":";host_name;persistent;author;comment","exampleArgStr":";host1;1;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"persistent","type":"bool"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"ADD_HOST_COMMENT","description":"This command is used to add a comment for the specified host.  If you work with other administrators, you may find it useful to share information about a host that is having problems if more than one of you may be working on it.  If you do not check the 'persistent' option, the comment will be automatically be deleted at the the next program restarted.","classes":["host","comment"],"commandType":4,"argsStr":";host_name;persistent;author;comment","exampleArgStr":";host1;1;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"persistent"
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/add_svc_comment.md
+++ b/src/documentation/developer/externalcommands/add_svc_comment.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"persistent","type":"bool"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"ADD_SVC_COMMENT","description":"This command is used to add a comment for the specified service.  If you work with other administrators, you may find it useful to share information about a host or service that is having problems if more than one of you may be working on it.  If you do not check the 'persistent' option, the comment will automatically be deleted at the next program restart.","classes":["service","comment"],"argsStr":";service;persistent;author;comment","exampleArgStr":";service1;1;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"persistent","type":"bool"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"ADD_SVC_COMMENT","description":"This command is used to add a comment for the specified service.  If you work with other administrators, you may find it useful to share information about a host or service that is having problems if more than one of you may be working on it.  If you do not check the 'persistent' option, the comment will automatically be deleted at the next program restart.","classes":["service","comment"],"commandType":6,"argsStr":";host_name;service_description;persistent;author;comment","exampleArgStr":";host1;service1;1;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"persistent
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_contact_host_notification_timeperiod.md
+++ b/src/documentation/developer/externalcommands/change_contact_host_notification_timeperiod.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"notification_timeperiod","type":"timeperiod"}],"name":"CHANGE_CONTACT_HOST_NOTIFICATION_TIMEPERIOD","description":"Changes the host notification timeperiod for a particular contact to what is specified by the 'notification_timeperiod' option. The 'notification_timeperiod' option should be the short name of the timeperiod that is to be used as the contact's host notification timeperiod. The timeperiod must have been configured in Naemon before it was last (re)started.","classes":["host","contact"],"argsStr":";contact_name;notification_timeperiod","exampleArgStr":";naemonadmin;24x7"};
+const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"notification_timeperiod","type":"timeperiod"}],"name":"CHANGE_CONTACT_HOST_NOTIFICATION_TIMEPERIOD","description":"Changes the host notification timeperiod for a particular contact to what is specified by the 'notification_timeperiod' option. The 'notification_timeperiod' option should be the short name of the timeperiod that is to be used as the contact's host notification timeperiod. The timeperiod must have been configured in Naemon before it was last (re)started.","classes":["host","contact"],"commandType":1,"argsStr":";contact_name;notification_timeperiod","exampleArgStr":";naemonadmin;24x7"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"notif
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_contact_modattr.md
+++ b/src/documentation/developer/externalcommands/change_contact_modattr.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"value","type":"ulong"}],"name":"CHANGE_CONTACT_MODATTR","description":"This command changes the modified attributes value for the specified contact. Modified attributes values are used by Naemon to determine which object properties should be retained across program restarts. Thus, modifying the value of the attributes can affect data retention. This is an advanced option and should only be used by people who are intimately familiar with the data retention logic in Naemon.","classes":["contact"],"argsStr":";contact_name;value","exampleArgStr":";naemonadmin;0"};
+const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"value","type":"ulong"}],"name":"CHANGE_CONTACT_MODATTR","description":"This command changes the modified attributes value for the specified contact. Modified attributes values are used by Naemon to determine which object properties should be retained across program restarts. Thus, modifying the value of the attributes can affect data retention. This is an advanced option and should only be used by people who are intimately familiar with the data retention logic in Naemon.","classes":["contact"],"commandType":1,"argsStr":";contact_name;value","exampleArgStr":";naemonadmin;0"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"value
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_contact_modhattr.md
+++ b/src/documentation/developer/externalcommands/change_contact_modhattr.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"value","type":"ulong"}],"name":"CHANGE_CONTACT_MODHATTR","description":"This command changes the modified host attributes value for the specified contact. Modified attributes values are used by Naemon to determine which object properties should be retained across program restarts. Thus, modifying the value of the attributes can affect data retention. This is an advanced option and should only be used by people who are intimately familiar with the data retention logic in Naemon.","classes":["contact"],"argsStr":";contact_name;value","exampleArgStr":";naemonadmin;0"};
+const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"value","type":"ulong"}],"name":"CHANGE_CONTACT_MODHATTR","description":"This command changes the modified host attributes value for the specified contact. Modified attributes values are used by Naemon to determine which object properties should be retained across program restarts. Thus, modifying the value of the attributes can affect data retention. This is an advanced option and should only be used by people who are intimately familiar with the data retention logic in Naemon.","classes":["contact"],"commandType":1,"argsStr":";contact_name;value","exampleArgStr":";naemonadmin;0"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"value
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_contact_modsattr.md
+++ b/src/documentation/developer/externalcommands/change_contact_modsattr.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"value","type":"ulong"}],"name":"CHANGE_CONTACT_MODSATTR","description":"This command changes the modified service attributes value for the specified contact. Modified attributes values are used by Naemon to determine which object properties should be retained across program restarts. Thus, modifying the value of the attributes can affect data retention. This is an advanced option and should only be used by people who are intimately familiar with the data retention logic in Naemon.","classes":["contact"],"argsStr":";contact_name;value","exampleArgStr":";naemonadmin;0"};
+const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"value","type":"ulong"}],"name":"CHANGE_CONTACT_MODSATTR","description":"This command changes the modified service attributes value for the specified contact. Modified attributes values are used by Naemon to determine which object properties should be retained across program restarts. Thus, modifying the value of the attributes can affect data retention. This is an advanced option and should only be used by people who are intimately familiar with the data retention logic in Naemon.","classes":["contact"],"commandType":1,"argsStr":";contact_name;value","exampleArgStr":";naemonadmin;0"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"value
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_contact_svc_notification_timeperiod.md
+++ b/src/documentation/developer/externalcommands/change_contact_svc_notification_timeperiod.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"notification_timeperiod","type":"timeperiod"}],"name":"CHANGE_CONTACT_SVC_NOTIFICATION_TIMEPERIOD","description":"Changes the service notification timeperiod for a particular contact to what is specified by the 'notification_timeperiod' option. The 'notification_timeperiod' option should be the short name of the timeperiod that is to be used as the contact's service notification timeperiod. The timeperiod must have been configured in Naemon before it was last (re)started.","classes":["service","contact"],"argsStr":";contact_name;notification_timeperiod","exampleArgStr":";naemonadmin;24x7"};
+const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"notification_timeperiod","type":"timeperiod"}],"name":"CHANGE_CONTACT_SVC_NOTIFICATION_TIMEPERIOD","description":"Changes the service notification timeperiod for a particular contact to what is specified by the 'notification_timeperiod' option. The 'notification_timeperiod' option should be the short name of the timeperiod that is to be used as the contact's service notification timeperiod. The timeperiod must have been configured in Naemon before it was last (re)started.","classes":["service","contact"],"commandType":1,"argsStr":";contact_name;notification_timeperiod","exampleArgStr":";naemonadmin;24x7"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"notif
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_custom_contact_var.md
+++ b/src/documentation/developer/externalcommands/change_custom_contact_var.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"varname","type":"str"},{"name":"varvalue","type":"str"}],"name":"CHANGE_CUSTOM_CONTACT_VAR","description":"Changes the value of a custom contact variable.","classes":["contact"],"argsStr":";contact_name;varname;varvalue","exampleArgStr":";naemonadmin;SOMEVAR;some new value"};
+const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"varname","type":"str"},{"name":"varvalue","type":"str"}],"name":"CHANGE_CUSTOM_CONTACT_VAR","description":"Changes the value of a custom contact variable.","classes":["contact"],"commandType":1,"argsStr":";contact_name;varname;varvalue","exampleArgStr":";naemonadmin;SOMEVAR;some new value","additionalInformation":"# This will change value of the custom variable: $_CONTACTSOMEVAR$\n"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"contact_name","type":"contact"},{"name":"varna
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_custom_host_var.md
+++ b/src/documentation/developer/externalcommands/change_custom_host_var.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"varname","type":"str"},{"name":"varvalue","type":"str"}],"name":"CHANGE_CUSTOM_HOST_VAR","description":"Changes the value of a custom host variable.","classes":["host"],"argsStr":";host_name;varname;varvalue","exampleArgStr":";host1;SOMEVAR;some new value"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"varname","type":"str"},{"name":"varvalue","type":"str"}],"name":"CHANGE_CUSTOM_HOST_VAR","description":"Changes the value of a custom host variable.","classes":["host"],"commandType":4,"argsStr":";host_name;varname;varvalue","exampleArgStr":";host1;SOMEVAR;some new value","additionalInformation":"# This will change value of the custom variable: $_HOSTSOMEVAR$\n"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"varname","t
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_custom_svc_var.md
+++ b/src/documentation/developer/externalcommands/change_custom_svc_var.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"varname","type":"str"},{"name":"varvalue","type":"str"}],"name":"CHANGE_CUSTOM_SVC_VAR","description":"Changes the value of a custom service variable.","classes":["service"],"argsStr":";service;varname;varvalue","exampleArgStr":";service1;SOMEVAR;some new value"};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"varname","type":"str"},{"name":"varvalue","type":"str"}],"name":"CHANGE_CUSTOM_SVC_VAR","description":"Changes the value of a custom service variable.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description;varname;varvalue","exampleArgStr":";host1;service1;SOMEVAR;some new value","additionalInformation":"# This will change value of the custom variable: $_SERVICESOMEVAR$\n"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"varname","
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_global_host_event_handler.md
+++ b/src/documentation/developer/externalcommands/change_global_host_event_handler.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"event_handler_command","type":"str"}],"name":"CHANGE_GLOBAL_HOST_EVENT_HANDLER","description":"Changes the global host event handler command to be that specified by the 'event_handler_command' option. The 'event_handler_command' option specifies the short name of the command that should be used as the new host event handler. The command must have been configured in Naemon before it was last (re)started.","classes":["host"],"argsStr":";event_handler_command","exampleArgStr":";restart_service"};
+const command = {"args":[{"name":"event_handler_command","type":"str"}],"name":"CHANGE_GLOBAL_HOST_EVENT_HANDLER","description":"Changes the global host event handler command to be that specified by the 'event_handler_command' option. The 'event_handler_command' option specifies the short name of the command that should be used as the new host event handler. The command must have been configured in Naemon before it was last (re)started.","classes":["host"],"commandType":4,"argsStr":";event_handler_command","exampleArgStr":";restart_service"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"event_handler_command","type":"str"}],"name":"
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_global_svc_event_handler.md
+++ b/src/documentation/developer/externalcommands/change_global_svc_event_handler.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"event_handler_command","type":"str"}],"name":"CHANGE_GLOBAL_SVC_EVENT_HANDLER","description":"Changes the global service event handler command to be that specified by the 'event_handler_command' option. The 'event_handler_command' option specifies the short name of the command that should be used as the new service event handler. The command must have been configured in Naemon before it was last (re)started.","classes":["service"],"argsStr":";event_handler_command","exampleArgStr":";restart_service"};
+const command = {"args":[{"name":"event_handler_command","type":"str"}],"name":"CHANGE_GLOBAL_SVC_EVENT_HANDLER","description":"Changes the global service event handler command to be that specified by the 'event_handler_command' option. The 'event_handler_command' option specifies the short name of the command that should be used as the new service event handler. The command must have been configured in Naemon before it was last (re)started.","classes":["service"],"commandType":6,"argsStr":";host_name;event_handler_command","exampleArgStr":";host1;restart_service"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"event_handler_command","type":"str"}],"name":"
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_host_check_command.md
+++ b/src/documentation/developer/externalcommands/change_host_check_command.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_command","type":"str"}],"name":"CHANGE_HOST_CHECK_COMMAND","description":"Changes the check command for a particular host to be that specified by the 'check_command' option. The 'check_command' option specifies the short name of the command that should be used as the new host check command. The command must have been configured in Naemon before it was last (re)started.","classes":["host"],"argsStr":";host_name;check_command","exampleArgStr":";host1;check_ping"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_command","type":"str"}],"name":"CHANGE_HOST_CHECK_COMMAND","description":"Changes the check command for a particular host to be that specified by the 'check_command' option. The 'check_command' option specifies the short name of the command that should be used as the new host check command. The command must have been configured in Naemon before it was last (re)started.","classes":["host"],"commandType":4,"argsStr":";host_name;check_command","exampleArgStr":";host1;check_ping"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_comma
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_host_check_timeperiod.md
+++ b/src/documentation/developer/externalcommands/change_host_check_timeperiod.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_timeperiod","type":"timeperiod"}],"name":"CHANGE_HOST_CHECK_TIMEPERIOD","description":"Changes the valid check period for the specified host.","classes":["host"],"argsStr":";host_name;check_timeperiod","exampleArgStr":";host1;24x7"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_timeperiod","type":"timeperiod"}],"name":"CHANGE_HOST_CHECK_TIMEPERIOD","description":"Changes the valid check period for the specified host.","classes":["host"],"commandType":4,"argsStr":";host_name;check_timeperiod","exampleArgStr":";host1;24x7"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_timep
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_host_event_handler.md
+++ b/src/documentation/developer/externalcommands/change_host_event_handler.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"event_handler_command","type":"str"}],"name":"CHANGE_HOST_EVENT_HANDLER","description":"Changes the event handler command for a particular host to be that specified by the 'event_handler_command' option. The 'event_handler_command' option specifies the short name of the command that should be used as the new host event handler. The command must have been configured in Naemon before it was last (re)started.","classes":["host"],"argsStr":";host_name;event_handler_command","exampleArgStr":";host1;restart_service"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"event_handler_command","type":"str"}],"name":"CHANGE_HOST_EVENT_HANDLER","description":"Changes the event handler command for a particular host to be that specified by the 'event_handler_command' option. The 'event_handler_command' option specifies the short name of the command that should be used as the new host event handler. The command must have been configured in Naemon before it was last (re)started.","classes":["host"],"commandType":4,"argsStr":";host_name;event_handler_command","exampleArgStr":";host1;restart_service"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"event_handl
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_host_modattr.md
+++ b/src/documentation/developer/externalcommands/change_host_modattr.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"value","type":"ulong"}],"name":"CHANGE_HOST_MODATTR","description":"This command changes the modified attributes value for the specified host. Modified attributes values are used by Naemon to determine which object properties should be retained across program restarts. Thus, modifying the value of the attributes can affect data retention. This is an advanced option and should only be used by people who are intimately familiar with the data retention logic in Naemon.","classes":["host"],"argsStr":";host_name;value","exampleArgStr":";host1;0"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"value","type":"ulong"}],"name":"CHANGE_HOST_MODATTR","description":"This command changes the modified attributes value for the specified host. Modified attributes values are used by Naemon to determine which object properties should be retained across program restarts. Thus, modifying the value of the attributes can affect data retention. This is an advanced option and should only be used by people who are intimately familiar with the data retention logic in Naemon.","classes":["host"],"commandType":4,"argsStr":";host_name;value","exampleArgStr":";host1;0"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"value","typ
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_host_notification_timeperiod.md
+++ b/src/documentation/developer/externalcommands/change_host_notification_timeperiod.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"notification_timeperiod","type":"timeperiod"}],"name":"CHANGE_HOST_NOTIFICATION_TIMEPERIOD","description":"Changes the host notification timeperiod to what is specified by the 'notification_timeperiod' option. The 'notification_timeperiod' option should be the short name of the timeperiod that is to be used as the service notification timeperiod. The timeperiod must have been configured in Naemon before it was last (re)started.","classes":["host"],"argsStr":";host_name;notification_timeperiod","exampleArgStr":";host1;24x7"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"notification_timeperiod","type":"timeperiod"}],"name":"CHANGE_HOST_NOTIFICATION_TIMEPERIOD","description":"Changes the host notification timeperiod to what is specified by the 'notification_timeperiod' option. The 'notification_timeperiod' option should be the short name of the timeperiod that is to be used as the service notification timeperiod. The timeperiod must have been configured in Naemon before it was last (re)started.","classes":["host"],"commandType":4,"argsStr":";host_name;notification_timeperiod","exampleArgStr":";host1;24x7"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"notificatio
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_max_host_check_attempts.md
+++ b/src/documentation/developer/externalcommands/change_max_host_check_attempts.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_attempts","type":"int"}],"name":"CHANGE_MAX_HOST_CHECK_ATTEMPTS","description":"Changes the maximum number of check attempts (retries) for a particular host.","classes":["host"],"argsStr":";host_name;check_attempts","exampleArgStr":";host1;10"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_attempts","type":"int"}],"name":"CHANGE_MAX_HOST_CHECK_ATTEMPTS","description":"Changes the maximum number of check attempts (retries) for a particular host.","classes":["host"],"commandType":4,"argsStr":";host_name;check_attempts","exampleArgStr":";host1;10"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_attem
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_max_svc_check_attempts.md
+++ b/src/documentation/developer/externalcommands/change_max_svc_check_attempts.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"check_attempts","type":"int"}],"name":"CHANGE_MAX_SVC_CHECK_ATTEMPTS","description":"Changes the maximum number of check attempts (retries) for a particular service.","classes":["service"],"argsStr":";service;check_attempts","exampleArgStr":";service1;10"};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"check_attempts","type":"int"}],"name":"CHANGE_MAX_SVC_CHECK_ATTEMPTS","description":"Changes the maximum number of check attempts (retries) for a particular service.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description;check_attempts","exampleArgStr":";host1;service1;10"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"check_atte
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_normal_host_check_interval.md
+++ b/src/documentation/developer/externalcommands/change_normal_host_check_interval.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_interval","type":"timestamp"}],"name":"CHANGE_NORMAL_HOST_CHECK_INTERVAL","description":"Changes the normal (regularly scheduled) check interval for a particular host.","classes":["host"],"argsStr":";host_name;check_interval","exampleArgStr":";host1;10"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_interval","type":"timestamp"}],"name":"CHANGE_NORMAL_HOST_CHECK_INTERVAL","description":"Changes the normal (regularly scheduled) check interval for a particular host.","classes":["host"],"commandType":4,"argsStr":";host_name;check_interval","exampleArgStr":";host1;10"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_inter
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_normal_svc_check_interval.md
+++ b/src/documentation/developer/externalcommands/change_normal_svc_check_interval.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"check_interval","type":"timestamp"}],"name":"CHANGE_NORMAL_SVC_CHECK_INTERVAL","description":"Changes the normal (regularly scheduled) check interval for a particular service","classes":["service"],"argsStr":";service;check_interval","exampleArgStr":";service1;10"};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"check_interval","type":"timestamp"}],"name":"CHANGE_NORMAL_SVC_CHECK_INTERVAL","description":"Changes the normal (regularly scheduled) check interval for a particular service","classes":["service"],"commandType":6,"argsStr":";host_name;service_description;check_interval","exampleArgStr":";host1;service1;10"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"check_inte
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_retry_host_check_interval.md
+++ b/src/documentation/developer/externalcommands/change_retry_host_check_interval.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_interval","type":"timestamp"}],"name":"CHANGE_RETRY_HOST_CHECK_INTERVAL","description":"Changes the retry check interval for a particular host.","classes":["host"],"argsStr":";host_name;check_interval","exampleArgStr":";host1;10"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_interval","type":"timestamp"}],"name":"CHANGE_RETRY_HOST_CHECK_INTERVAL","description":"Changes the retry check interval for a particular host.","classes":["host"],"commandType":4,"argsStr":";host_name;check_interval","exampleArgStr":";host1;10"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_inter
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_retry_svc_check_interval.md
+++ b/src/documentation/developer/externalcommands/change_retry_svc_check_interval.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"check_interval","type":"timestamp"}],"name":"CHANGE_RETRY_SVC_CHECK_INTERVAL","description":"Changes the retry check interval for a particular service.","classes":["service"],"argsStr":";service;check_interval","exampleArgStr":";service1;10"};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"check_interval","type":"timestamp"}],"name":"CHANGE_RETRY_SVC_CHECK_INTERVAL","description":"Changes the retry check interval for a particular service.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description;check_interval","exampleArgStr":";host1;service1;10"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"check_inte
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_svc_check_command.md
+++ b/src/documentation/developer/externalcommands/change_svc_check_command.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"check_command","type":"str"}],"name":"CHANGE_SVC_CHECK_COMMAND","description":"Changes the check command for a particular service to be that specified by the 'check_command' option. The 'check_command' option specifies the short name of the command that should be used as the new service check command. The command must have been configured in Naemon before it was last (re)started.","classes":["service"],"argsStr":";service;check_command","exampleArgStr":";service1;check_ping"};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"check_command","type":"str"}],"name":"CHANGE_SVC_CHECK_COMMAND","description":"Changes the check command for a particular service to be that specified by the 'check_command' option. The 'check_command' option specifies the short name of the command that should be used as the new service check command. The command must have been configured in Naemon before it was last (re)started.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description;check_command","exampleArgStr":";host1;service1;check_ping"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"check_comm
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_svc_check_timeperiod.md
+++ b/src/documentation/developer/externalcommands/change_svc_check_timeperiod.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"check_timeperiod","type":"timeperiod"}],"name":"CHANGE_SVC_CHECK_TIMEPERIOD","description":"Changes the check timeperiod for a particular service to what is specified by the 'check_timeperiod' option. The 'check_timeperiod' option should be the short name of the timeperod that is to be used as the service check timeperiod. The timeperiod must have been configured in Naemon before it was last (re)started.","classes":["service"],"argsStr":";service;check_timeperiod","exampleArgStr":";service1;24x7"};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"check_timeperiod","type":"timeperiod"}],"name":"CHANGE_SVC_CHECK_TIMEPERIOD","description":"Changes the check timeperiod for a particular service to what is specified by the 'check_timeperiod' option. The 'check_timeperiod' option should be the short name of the timeperod that is to be used as the service check timeperiod. The timeperiod must have been configured in Naemon before it was last (re)started.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description;check_timeperiod","exampleArgStr":";host1;service1;24x7"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"check_time
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_svc_event_handler.md
+++ b/src/documentation/developer/externalcommands/change_svc_event_handler.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"event_handler_command","type":"str"}],"name":"CHANGE_SVC_EVENT_HANDLER","description":"Changes the event handler command for a particular service to be that specified by the 'event_handler_command' option. The 'event_handler_command' option specifies the short name of the command that should be used as the new service event handler. The command must have been configured in Naemon before it was last (re)started.","classes":["service"],"argsStr":";service;event_handler_command","exampleArgStr":";service1;restart_service"};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"event_handler_command","type":"str"}],"name":"CHANGE_SVC_EVENT_HANDLER","description":"Changes the event handler command for a particular service to be that specified by the 'event_handler_command' option. The 'event_handler_command' option specifies the short name of the command that should be used as the new service event handler. The command must have been configured in Naemon before it was last (re)started.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description;event_handler_command","exampleArgStr":";host1;service1;restart_service"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"event_hand
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_svc_modattr.md
+++ b/src/documentation/developer/externalcommands/change_svc_modattr.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"value","type":"ulong"}],"name":"CHANGE_SVC_MODATTR","description":"This command changes the modified attributes value for the specified service. Modified attributes values are used by Naemon to determine which object properties should be retained across program restarts. Thus, modifying the value of the attributes can affect data retention. This is an advanced option and should only be used by people who are intimately familiar with the data retention logic in Naemon.","classes":["service"],"argsStr":";service;value","exampleArgStr":";service1;0"};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"value","type":"ulong"}],"name":"CHANGE_SVC_MODATTR","description":"This command changes the modified attributes value for the specified service. Modified attributes values are used by Naemon to determine which object properties should be retained across program restarts. Thus, modifying the value of the attributes can affect data retention. This is an advanced option and should only be used by people who are intimately familiar with the data retention logic in Naemon.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description;value","exampleArgStr":";host1;service1;0"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"value","ty
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/change_svc_notification_timeperiod.md
+++ b/src/documentation/developer/externalcommands/change_svc_notification_timeperiod.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"notification_timeperiod","type":"timeperiod"}],"name":"CHANGE_SVC_NOTIFICATION_TIMEPERIOD","description":"Changes the service notification timeperiod to what is specified by the 'notification_timeperiod' option. The 'notification_timeperiod' option should be the short name of the timeperiod that is to be used as the service notification timeperiod. The timeperiod must have been configured in Naemon before it was last (re)started.","classes":["service"],"argsStr":";service;notification_timeperiod","exampleArgStr":";service1;24x7"};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"notification_timeperiod","type":"timeperiod"}],"name":"CHANGE_SVC_NOTIFICATION_TIMEPERIOD","description":"Changes the service notification timeperiod to what is specified by the 'notification_timeperiod' option. The 'notification_timeperiod' option should be the short name of the timeperiod that is to be used as the service notification timeperiod. The timeperiod must have been configured in Naemon before it was last (re)started.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description;notification_timeperiod","exampleArgStr":";host1;service1;24x7"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"notificati
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_all_host_comments.md
+++ b/src/documentation/developer/externalcommands/del_all_host_comments.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"DEL_ALL_HOST_COMMENTS","description":"Deletes all comments associated with a particular host.","classes":["host","comment"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"DEL_ALL_HOST_COMMENTS","description":"Deletes all comments associated with a particular host.","classes":["host","comment"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DEL_ALL_HOS
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_all_svc_comments.md
+++ b/src/documentation/developer/externalcommands/del_all_svc_comments.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"}],"name":"DEL_ALL_SVC_COMMENTS","description":"Deletes all comments associated with a particular service.","classes":["service","comment"],"argsStr":";service","exampleArgStr":";service1"};
+const command = {"args":[{"name":"service_description","type":"service"}],"name":"DEL_ALL_SVC_COMMENTS","description":"Deletes all comments associated with a particular service.","classes":["service","comment"],"commandType":6,"argsStr":";host_name;service_description","exampleArgStr":";host1;service1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"DEL_ALL_SV
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_downtime_by_host_name.md
+++ b/src/documentation/developer/externalcommands/del_downtime_by_host_name.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"DEL_DOWNTIME_BY_HOST_NAME","description":"This command deletes all downtimes matching the specified filters.","classes":["host","downtime"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"DEL_DOWNTIME_BY_HOST_NAME","description":"This command deletes all downtimes matching the specified filters.","classes":["host","downtime"],"commandType":4,"argsStr":"","exampleArgStr":""};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"DEL_DOWNTIME_BY_HOST_NAME","description":"Thi
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_downtime_by_hostgroup_name.md
+++ b/src/documentation/developer/externalcommands/del_downtime_by_hostgroup_name.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostname","type":"STRING"},{"name":"service_description","type":"STRING"},{"name":"downtime_start_time","type":"TIMESTAMP"},{"name":"comment","type":"STRING"}],"name":"DEL_DOWNTIME_BY_HOSTGROUP_NAME","description":"This command deletes all downtimes matching the specified filters.","classes":["hostgroup","downtime"],"argsStr":";hostname;service_description;downtime_start_time;comment","exampleArgStr":";host1;service1;1478648441;This is an example comment."};
+const command = {"args":[{"name":"hostname","type":"STRING"},{"name":"service_description","type":"STRING"},{"name":"downtime_start_time","type":"TIMESTAMP"},{"name":"comment","type":"STRING"}],"name":"DEL_DOWNTIME_BY_HOSTGROUP_NAME","description":"This command deletes all downtimes matching the specified filters.","classes":["hostgroup","downtime"],"commandType":5,"argsStr":";hostname;service_description;downtime_start_time;comment","exampleArgStr":";host1;service1;1478648441;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostname","type":"STRING"},{"name":"service_de
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_downtime_by_start_time_comment.md
+++ b/src/documentation/developer/externalcommands/del_downtime_by_start_time_comment.md
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"HOSTGROUP"},{"name":"h
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_host_comment.md
+++ b/src/documentation/developer/externalcommands/del_host_comment.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"comment_id","type":"ulong"}],"name":"DEL_HOST_COMMENT","description":"This command is used to delete a specific host comment.","classes":["host","comment"],"argsStr":";comment_id","exampleArgStr":";1234"};
+const command = {"args":[{"name":"comment_id","type":"ulong"}],"name":"DEL_HOST_COMMENT","description":"This command is used to delete a specific host comment.","classes":["host","comment"],"commandType":4,"argsStr":";comment_id","exampleArgStr":";1234"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"comment_id","type":"ulong"}],"name":"DEL_HOST_
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_host_downtime.md
+++ b/src/documentation/developer/externalcommands/del_host_downtime.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"downtime_id","type":"ulong"}],"name":"DEL_HOST_DOWNTIME","description":"Deletes the host downtime entry that has an ID number matching the 'downtime_id' argument. If the downtime is currently in effect, the host will come out of scheduled downtime (as long as there are no other overlapping active downtime entries).","classes":["host","downtime"],"argsStr":";downtime_id","exampleArgStr":";1234"};
+const command = {"args":[{"name":"downtime_id","type":"ulong"}],"name":"DEL_HOST_DOWNTIME","description":"Deletes the host downtime entry that has an ID number matching the 'downtime_id' argument. If the downtime is currently in effect, the host will come out of scheduled downtime (as long as there are no other overlapping active downtime entries).","classes":["host","downtime"],"commandType":4,"argsStr":";downtime_id","exampleArgStr":";1234"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"downtime_id","type":"ulong"}],"name":"DEL_HOST
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_svc_comment.md
+++ b/src/documentation/developer/externalcommands/del_svc_comment.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"comment_id","type":"ulong"}],"name":"DEL_SVC_COMMENT","description":"This command is used to delete a specific service comment.","classes":["service","comment"],"argsStr":";comment_id","exampleArgStr":";1234"};
+const command = {"args":[{"name":"comment_id","type":"ulong"}],"name":"DEL_SVC_COMMENT","description":"This command is used to delete a specific service comment.","classes":["service","comment"],"commandType":6,"argsStr":";host_name;comment_id","exampleArgStr":";host1;1234"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"comment_id","type":"ulong"}],"name":"DEL_SVC_C
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/del_svc_downtime.md
+++ b/src/documentation/developer/externalcommands/del_svc_downtime.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"downtime_id","type":"ulong"}],"name":"DEL_SVC_DOWNTIME","description":"Deletes the service downtime entry that has an ID number matching the 'downtime_id' argument. If the downtime is currently in effect, the service will come out of scheduled downtime (as long as there are no other overlapping active downtime entries).","classes":["service","downtime"],"argsStr":";downtime_id","exampleArgStr":";1234"};
+const command = {"args":[{"name":"downtime_id","type":"ulong"}],"name":"DEL_SVC_DOWNTIME","description":"Deletes the service downtime entry that has an ID number matching the 'downtime_id' argument. If the downtime is currently in effect, the service will come out of scheduled downtime (as long as there are no other overlapping active downtime entries).","classes":["service","downtime"],"commandType":6,"argsStr":";host_name;downtime_id","exampleArgStr":";host1;1234"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"downtime_id","type":"ulong"}],"name":"DEL_SVC_
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/delay_host_notification.md
+++ b/src/documentation/developer/externalcommands/delay_host_notification.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"notification_time","type":"timestamp"}],"name":"DELAY_HOST_NOTIFICATION","description":"Delays the next notification for a parciular service until 'notification_time'. The 'notification_time' argument is specified in time_t format (seconds since the UNIX epoch). Note that this will only have an affect if the service stays in the same problem state that it is currently in. If the service changes to another state, a new notification may go out before the time you specify in the 'notification_time' argument.","classes":["host"],"argsStr":";host_name;notification_time","exampleArgStr":";host1;1478638441"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"notification_time","type":"timestamp"}],"name":"DELAY_HOST_NOTIFICATION","description":"Delays the next notification for a parciular service until 'notification_time'. The 'notification_time' argument is specified in time_t format (seconds since the UNIX epoch). Note that this will only have an affect if the service stays in the same problem state that it is currently in. If the service changes to another state, a new notification may go out before the time you specify in the 'notification_time' argument.","classes":["host"],"commandType":4,"argsStr":";host_name;notification_time","exampleArgStr":";host1;1478638441"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"notificatio
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/delay_svc_notification.md
+++ b/src/documentation/developer/externalcommands/delay_svc_notification.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"notification_time","type":"timestamp"}],"name":"DELAY_SVC_NOTIFICATION","description":"Delays the next notification for a parciular service until 'notification_time'. The 'notification_time' argument is specified in time_t format (seconds since the UNIX epoch). Note that this will only have an affect if the service stays in the same problem state that it is currently in. If the service changes to another state, a new notification may go out before the time you specify in the 'notification_time' argument.","classes":["service"],"argsStr":";service;notification_time","exampleArgStr":";service1;1478638441"};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"notification_time","type":"timestamp"}],"name":"DELAY_SVC_NOTIFICATION","description":"Delays the next notification for a parciular service until 'notification_time'. The 'notification_time' argument is specified in time_t format (seconds since the UNIX epoch). Note that this will only have an affect if the service stays in the same problem state that it is currently in. If the service changes to another state, a new notification may go out before the time you specify in the 'notification_time' argument.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description;notification_time","exampleArgStr":";host1;service1;1478638441"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"notificati
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_all_notifications_beyond_host.md
+++ b/src/documentation/developer/externalcommands/disable_all_notifications_beyond_host.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST","description":"Disables notifications for all hosts and services 'beyond' (e.g. on all child hosts of) the specified host. The current notification setting for the specified host is not affected.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST","description":"Disables notifications for all hosts and services 'beyond' (e.g. on all child hosts of) the specified host. The current notification setting for the specified host is not affected.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_ALL
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_contact_host_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_contact_host_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"DISABLE_CONTACT_HOST_NOTIFICATIONS","description":"Disables host notifications for a particular contact.","classes":["host","contact"],"argsStr":";contact_name","exampleArgStr":";naemonadmin"};
+const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"DISABLE_CONTACT_HOST_NOTIFICATIONS","description":"Disables host notifications for a particular contact.","classes":["host","contact"],"commandType":1,"argsStr":";contact_name","exampleArgStr":";naemonadmin"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"DISAB
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_contact_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_contact_svc_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"DISABLE_CONTACT_SVC_NOTIFICATIONS","description":"Disables service notifications for a particular contact.","classes":["service","contact"],"argsStr":";contact_name","exampleArgStr":";naemonadmin"};
+const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"DISABLE_CONTACT_SVC_NOTIFICATIONS","description":"Disables service notifications for a particular contact.","classes":["service","contact"],"commandType":1,"argsStr":";contact_name","exampleArgStr":";naemonadmin"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"DISAB
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_contactgroup_host_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_contactgroup_host_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"name":"DISABLE_CONTACTGROUP_HOST_NOTIFICATIONS","description":"Disables host notifications for all contacts in a particular contactgroup.","classes":["host","contactgroup"],"argsStr":";contactgroup_name","exampleArgStr":";contactgroup1"};
+const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"name":"DISABLE_CONTACTGROUP_HOST_NOTIFICATIONS","description":"Disables host notifications for all contacts in a particular contactgroup.","classes":["host","contactgroup"],"commandType":2,"argsStr":";contactgroup_name","exampleArgStr":";contactgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_contactgroup_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_contactgroup_svc_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"name":"DISABLE_CONTACTGROUP_SVC_NOTIFICATIONS","description":"Disables service notifications for all contacts in a particular contactgroup.","classes":["service","contactgroup"],"argsStr":";contactgroup_name","exampleArgStr":";contactgroup1"};
+const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"name":"DISABLE_CONTACTGROUP_SVC_NOTIFICATIONS","description":"Disables service notifications for all contacts in a particular contactgroup.","classes":["service","contactgroup"],"commandType":2,"argsStr":";contactgroup_name","exampleArgStr":";contactgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_event_handlers.md
+++ b/src/documentation/developer/externalcommands/disable_event_handlers.md
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"DISABLE_EVENT_HANDLERS","description":"Disabl
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_flap_detection.md
+++ b/src/documentation/developer/externalcommands/disable_flap_detection.md
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"DISABLE_FLAP_DETECTION","description":"Disabl
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_and_child_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_host_and_child_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOST_AND_CHILD_NOTIFICATIONS","description":"Disables notifications for the specified host, as well as all hosts 'beyond' (e.g. on all child hosts of) the specified host.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOST_AND_CHILD_NOTIFICATIONS","description":"Disables notifications for the specified host, as well as all hosts 'beyond' (e.g. on all child hosts of) the specified host.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOS
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_check.md
+++ b/src/documentation/developer/externalcommands/disable_host_check.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOST_CHECK","description":"Disables (regularly scheduled and on-demand) active checks of the specified host.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOST_CHECK","description":"Disables (regularly scheduled and on-demand) active checks of the specified host.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOS
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_event_handler.md
+++ b/src/documentation/developer/externalcommands/disable_host_event_handler.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOST_EVENT_HANDLER","description":"Disables the event handler for the specified host.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOST_EVENT_HANDLER","description":"Disables the event handler for the specified host.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOS
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_flap_detection.md
+++ b/src/documentation/developer/externalcommands/disable_host_flap_detection.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOST_FLAP_DETECTION","description":"Disables flap detection for the specified host.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOST_FLAP_DETECTION","description":"Disables flap detection for the specified host.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOS
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_freshness_checks.md
+++ b/src/documentation/developer/externalcommands/disable_host_freshness_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"DISABLE_HOST_FRESHNESS_CHECKS","description":"Disables freshness checks of all hosts on a program-wide basis.","classes":["host"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"DISABLE_HOST_FRESHNESS_CHECKS","description":"Disables freshness checks of all hosts on a program-wide basis.","classes":["host"],"commandType":4,"argsStr":"","exampleArgStr":""};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"DISABLE_HOST_FRESHNESS_CHECKS","description":
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_host_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOST_NOTIFICATIONS","description":"Disables notifications for a particular host.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOST_NOTIFICATIONS","description":"Disables notifications for a particular host.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOS
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_svc_checks.md
+++ b/src/documentation/developer/externalcommands/disable_host_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOST_SVC_CHECKS","description":"Disables active checks of all services on the specified host","classes":["host","service"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOST_SVC_CHECKS","description":"Disables active checks of all services on the specified host","classes":["host","service"],"commandType":6,"argsStr":";host_name;host_name","exampleArgStr":";host1;host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOS
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_host_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_host_svc_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOST_SVC_NOTIFICATIONS","description":"Disables notifications for all services on the specified host.","classes":["host","service"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOST_SVC_NOTIFICATIONS","description":"Disables notifications for all services on the specified host.","classes":["host","service"],"commandType":6,"argsStr":";host_name;host_name","exampleArgStr":";host1;host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_HOS
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_hostgroup_host_checks.md
+++ b/src/documentation/developer/externalcommands/disable_hostgroup_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"DISABLE_HOSTGROUP_HOST_CHECKS","description":"Disables active checks for all hosts in a particular hostgroup.","classes":["hostgroup"],"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
+const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"DISABLE_HOSTGROUP_HOST_CHECKS","description":"Disables active checks for all hosts in a particular hostgroup.","classes":["hostgroup"],"commandType":5,"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"D
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_hostgroup_host_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_hostgroup_host_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"DISABLE_HOSTGROUP_HOST_NOTIFICATIONS","description":"Disables notifications for all hosts in a particular hostgroup. This does not disable notifications for the services associated with the hosts in the hostgroup - see the DISABLE_HOSTGROUP_SVC_NOTIFICATIONS command for that.","classes":["hostgroup"],"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
+const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"DISABLE_HOSTGROUP_HOST_NOTIFICATIONS","description":"Disables notifications for all hosts in a particular hostgroup. This does not disable notifications for the services associated with the hosts in the hostgroup - see the DISABLE_HOSTGROUP_SVC_NOTIFICATIONS command for that.","classes":["hostgroup"],"commandType":5,"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"D
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_hostgroup_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/disable_hostgroup_passive_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"DISABLE_HOSTGROUP_PASSIVE_HOST_CHECKS","description":"Disables passive checks for all hosts in a particular hostgroup.","classes":["hostgroup"],"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
+const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"DISABLE_HOSTGROUP_PASSIVE_HOST_CHECKS","description":"Disables passive checks for all hosts in a particular hostgroup.","classes":["hostgroup"],"commandType":5,"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"D
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_hostgroup_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/disable_hostgroup_passive_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"DISABLE_HOSTGROUP_PASSIVE_SVC_CHECKS","description":"Disables passive checks for all services associated with hosts in a particular hostgroup.","classes":["hostgroup","service"],"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
+const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"DISABLE_HOSTGROUP_PASSIVE_SVC_CHECKS","description":"Disables passive checks for all services associated with hosts in a particular hostgroup.","classes":["hostgroup","service"],"commandType":6,"argsStr":";host_name;hostgroup_name","exampleArgStr":";host1;hostgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"D
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_hostgroup_svc_checks.md
+++ b/src/documentation/developer/externalcommands/disable_hostgroup_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"DISABLE_HOSTGROUP_SVC_CHECKS","description":"Disables active checks for all services associated with hosts in a particular hostgroup.","classes":["hostgroup","service"],"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
+const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"DISABLE_HOSTGROUP_SVC_CHECKS","description":"Disables active checks for all services associated with hosts in a particular hostgroup.","classes":["hostgroup","service"],"commandType":6,"argsStr":";host_name;hostgroup_name","exampleArgStr":";host1;hostgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"D
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_hostgroup_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_hostgroup_svc_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"DISABLE_HOSTGROUP_SVC_NOTIFICATIONS","description":"Disables notifications for all services associated with hosts in a particular hostgroup. This does not disable notifications for the hosts in the hostgroup - see the DISABLE_HOSTGROUP_HOST_NOTIFICATIONS command for that.","classes":["hostgroup","service"],"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
+const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"DISABLE_HOSTGROUP_SVC_NOTIFICATIONS","description":"Disables notifications for all services associated with hosts in a particular hostgroup. This does not disable notifications for the hosts in the hostgroup - see the DISABLE_HOSTGROUP_HOST_NOTIFICATIONS command for that.","classes":["hostgroup","service"],"commandType":6,"argsStr":";host_name;hostgroup_name","exampleArgStr":";host1;hostgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"D
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_notifications.md
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"DISABLE_NOTIFICATIONS","description":"Disable
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/disable_passive_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_PASSIVE_HOST_CHECKS","description":"Disables acceptance and processing of passive host checks for the specified host.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_PASSIVE_HOST_CHECKS","description":"Disables acceptance and processing of passive host checks for the specified host.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"DISABLE_PAS
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/disable_passive_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_PASSIVE_SVC_CHECKS","description":"Disables passive checks for the specified service.","classes":["service"],"argsStr":";service","exampleArgStr":";service1"};
+const command = {"args":[{"name":"service_description","type":"service"}],"name":"DISABLE_PASSIVE_SVC_CHECKS","description":"Disables passive checks for the specified service.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description","exampleArgStr":";host1;service1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_PA
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_performance_data.md
+++ b/src/documentation/developer/externalcommands/disable_performance_data.md
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"DISABLE_PERFORMANCE_DATA","description":"Disa
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_service_freshness_checks.md
+++ b/src/documentation/developer/externalcommands/disable_service_freshness_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"DISABLE_SERVICE_FRESHNESS_CHECKS","description":"Disables freshness checks of all services on a program-wide basis.","classes":["service"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"DISABLE_SERVICE_FRESHNESS_CHECKS","description":"Disables freshness checks of all services on a program-wide basis.","classes":["service"],"commandType":6,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"DISABLE_SERVICE_FRESHNESS_CHECKS","descriptio
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_servicegroup_host_checks.md
+++ b/src/documentation/developer/externalcommands/disable_servicegroup_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"DISABLE_SERVICEGROUP_HOST_CHECKS","description":"Disables active checks for all hosts that have services that are members of a particular hostgroup.","classes":["host","servicegroup"],"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
+const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"DISABLE_SERVICEGROUP_HOST_CHECKS","description":"Disables active checks for all hosts that have services that are members of a particular hostgroup.","classes":["host","servicegroup"],"commandType":7,"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_servicegroup_host_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_servicegroup_host_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"DISABLE_SERVICEGROUP_HOST_NOTIFICATIONS","description":"Disables notifications for all hosts that have services that are members of a particular servicegroup.","classes":["host","servicegroup"],"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
+const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"DISABLE_SERVICEGROUP_HOST_NOTIFICATIONS","description":"Disables notifications for all hosts that have services that are members of a particular servicegroup.","classes":["host","servicegroup"],"commandType":7,"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_servicegroup_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/disable_servicegroup_passive_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"DISABLE_SERVICEGROUP_PASSIVE_HOST_CHECKS","description":"Disables the acceptance and processing of passive checks for all hosts that have services that are members of a particular service group.","classes":["host","servicegroup"],"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
+const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"DISABLE_SERVICEGROUP_PASSIVE_HOST_CHECKS","description":"Disables the acceptance and processing of passive checks for all hosts that have services that are members of a particular service group.","classes":["host","servicegroup"],"commandType":7,"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_servicegroup_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/disable_servicegroup_passive_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"DISABLE_SERVICEGROUP_PASSIVE_SVC_CHECKS","description":"Disables the acceptance and processing of passive checks for all services in a particular servicegroup.","classes":["servicegroup"],"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
+const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"DISABLE_SERVICEGROUP_PASSIVE_SVC_CHECKS","description":"Disables the acceptance and processing of passive checks for all services in a particular servicegroup.","classes":["servicegroup"],"commandType":7,"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_servicegroup_svc_checks.md
+++ b/src/documentation/developer/externalcommands/disable_servicegroup_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"DISABLE_SERVICEGROUP_SVC_CHECKS","description":"Disables active checks for all services in a particular servicegroup.","classes":["servicegroup"],"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
+const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"DISABLE_SERVICEGROUP_SVC_CHECKS","description":"Disables active checks for all services in a particular servicegroup.","classes":["servicegroup"],"commandType":7,"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_servicegroup_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_servicegroup_svc_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"DISABLE_SERVICEGROUP_SVC_NOTIFICATIONS","description":"Disables notifications for all services that are members of a particular servicegroup.","classes":["servicegroup"],"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
+const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"DISABLE_SERVICEGROUP_SVC_NOTIFICATIONS","description":"Disables notifications for all services that are members of a particular servicegroup.","classes":["servicegroup"],"commandType":7,"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_svc_check.md
+++ b/src/documentation/developer/externalcommands/disable_svc_check.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_SVC_CHECK","description":"This command is used to disable active checks of a service.","classes":["service"],"argsStr":";service","exampleArgStr":";service1"};
+const command = {"args":[{"name":"service_description","type":"service"}],"name":"DISABLE_SVC_CHECK","description":"This command is used to disable active checks of a service.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description","exampleArgStr":";host1;service1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_SV
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_svc_event_handler.md
+++ b/src/documentation/developer/externalcommands/disable_svc_event_handler.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_SVC_EVENT_HANDLER","description":"Disables the event handler for the specified service.","classes":["service"],"argsStr":";service","exampleArgStr":";service1"};
+const command = {"args":[{"name":"service_description","type":"service"}],"name":"DISABLE_SVC_EVENT_HANDLER","description":"Disables the event handler for the specified service.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description","exampleArgStr":";host1;service1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_SV
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_svc_flap_detection.md
+++ b/src/documentation/developer/externalcommands/disable_svc_flap_detection.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_SVC_FLAP_DETECTION","description":"Disables flap detection for the specified service.","classes":["service"],"argsStr":";service","exampleArgStr":";service1"};
+const command = {"args":[{"name":"service_description","type":"service"}],"name":"DISABLE_SVC_FLAP_DETECTION","description":"Disables flap detection for the specified service.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description","exampleArgStr":";host1;service1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_SV
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/disable_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/disable_svc_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_SVC_NOTIFICATIONS","description":"Disables notifications for a particular service.","classes":["service"],"argsStr":";service","exampleArgStr":";service1"};
+const command = {"args":[{"name":"service_description","type":"service"}],"name":"DISABLE_SVC_NOTIFICATIONS","description":"Disables notifications for a particular service.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description","exampleArgStr":";host1;service1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"DISABLE_SV
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_all_notifications_beyond_host.md
+++ b/src/documentation/developer/externalcommands/enable_all_notifications_beyond_host.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST","description":"Enables notifications for all hosts and services 'beyond' (e.g. on all child hosts of) the specified host. The current notification setting for the specified host is not affected. Notifications will only be sent out for these hosts and services if notifications are also enabled on a program-wide basis.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST","description":"Enables notifications for all hosts and services 'beyond' (e.g. on all child hosts of) the specified host. The current notification setting for the specified host is not affected. Notifications will only be sent out for these hosts and services if notifications are also enabled on a program-wide basis.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_ALL_
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_contact_host_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_contact_host_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"ENABLE_CONTACT_HOST_NOTIFICATIONS","description":"Enables host notifications for a particular contact.","classes":["host","contact"],"argsStr":";contact_name","exampleArgStr":";naemonadmin"};
+const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"ENABLE_CONTACT_HOST_NOTIFICATIONS","description":"Enables host notifications for a particular contact.","classes":["host","contact"],"commandType":1,"argsStr":";contact_name","exampleArgStr":";naemonadmin"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"ENABL
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_contact_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_contact_svc_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"ENABLE_CONTACT_SVC_NOTIFICATIONS","description":"Disables service notifications for a particular contact.","classes":["service","contact"],"argsStr":";contact_name","exampleArgStr":";naemonadmin"};
+const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"ENABLE_CONTACT_SVC_NOTIFICATIONS","description":"Disables service notifications for a particular contact.","classes":["service","contact"],"commandType":1,"argsStr":";contact_name","exampleArgStr":";naemonadmin"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"contact_name","type":"contact"}],"name":"ENABL
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_contactgroup_host_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_contactgroup_host_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"name":"ENABLE_CONTACTGROUP_HOST_NOTIFICATIONS","description":"Enables host notifications for all contacts in a particular contactgroup.","classes":["host","contactgroup"],"argsStr":";contactgroup_name","exampleArgStr":";contactgroup1"};
+const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"name":"ENABLE_CONTACTGROUP_HOST_NOTIFICATIONS","description":"Enables host notifications for all contacts in a particular contactgroup.","classes":["host","contactgroup"],"commandType":2,"argsStr":";contactgroup_name","exampleArgStr":";contactgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_contactgroup_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_contactgroup_svc_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"name":"ENABLE_CONTACTGROUP_SVC_NOTIFICATIONS","description":"Enables service notifications for all contacts in a particular contactgroup.","classes":["service","contactgroup"],"argsStr":";contactgroup_name","exampleArgStr":";contactgroup1"};
+const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"name":"ENABLE_CONTACTGROUP_SVC_NOTIFICATIONS","description":"Enables service notifications for all contacts in a particular contactgroup.","classes":["service","contactgroup"],"commandType":2,"argsStr":";contactgroup_name","exampleArgStr":";contactgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"contactgroup_name","type":"contactgroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_event_handlers.md
+++ b/src/documentation/developer/externalcommands/enable_event_handlers.md
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"downtime_start_time","type":"TIMESTAMP"},{"nam
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_flap_detection.md
+++ b/src/documentation/developer/externalcommands/enable_flap_detection.md
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"ENABLE_FLAP_DETECTION","description":"Enables
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_and_child_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_host_and_child_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST_AND_CHILD_NOTIFICATIONS","description":"Enables notifications for the specified host, as well as all hosts 'beyond' (e.g. on all child hosts of) the specified host. Notifications will only be sent out for these hosts if notifications are also enabled on a program-wide basis.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST_AND_CHILD_NOTIFICATIONS","description":"Enables notifications for the specified host, as well as all hosts 'beyond' (e.g. on all child hosts of) the specified host. Notifications will only be sent out for these hosts if notifications are also enabled on a program-wide basis.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_check.md
+++ b/src/documentation/developer/externalcommands/enable_host_check.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST_CHECK","description":"Enables (regularly scheduled and on-demand) active checks of the specified host.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST_CHECK","description":"Enables (regularly scheduled and on-demand) active checks of the specified host.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_event_handler.md
+++ b/src/documentation/developer/externalcommands/enable_host_event_handler.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST_EVENT_HANDLER","description":"Enables the event handler for the specified host.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST_EVENT_HANDLER","description":"Enables the event handler for the specified host.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_flap_detection.md
+++ b/src/documentation/developer/externalcommands/enable_host_flap_detection.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST_FLAP_DETECTION","description":"Enables flap detection for the specified host.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST_FLAP_DETECTION","description":"Enables flap detection for the specified host.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_freshness_checks.md
+++ b/src/documentation/developer/externalcommands/enable_host_freshness_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"ENABLE_HOST_FRESHNESS_CHECKS","description":"Enables freshness checks of all hosts on a program-wide basis. Individual hosts that have freshness checks disabled will not be checked for freshness.","classes":["host"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"ENABLE_HOST_FRESHNESS_CHECKS","description":"Enables freshness checks of all hosts on a program-wide basis. Individual hosts that have freshness checks disabled will not be checked for freshness.","classes":["host"],"commandType":4,"argsStr":"","exampleArgStr":""};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"ENABLE_HOST_FRESHNESS_CHECKS","description":"
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_host_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST_NOTIFICATIONS","description":"Enables notifications for a particular host. Notifications will be sent out for the host only if notifications are enabled on a program-wide basis as well.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST_NOTIFICATIONS","description":"Enables notifications for a particular host. Notifications will be sent out for the host only if notifications are enabled on a program-wide basis as well.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_svc_checks.md
+++ b/src/documentation/developer/externalcommands/enable_host_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST_SVC_CHECKS","description":"Enables active checks of all services on the specified host.","classes":["host","service"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST_SVC_CHECKS","description":"Enables active checks of all services on the specified host.","classes":["host","service"],"commandType":6,"argsStr":";host_name;host_name","exampleArgStr":";host1;host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_host_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_host_svc_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST_SVC_NOTIFICATIONS","description":"Enables notifications for all services on the specified host. Note that notifications will not be sent out if notifications are disabled on a program-wide basis.","classes":["host","service"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST_SVC_NOTIFICATIONS","description":"Enables notifications for all services on the specified host. Note that notifications will not be sent out if notifications are disabled on a program-wide basis.","classes":["host","service"],"commandType":6,"argsStr":";host_name;host_name","exampleArgStr":";host1;host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_HOST
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_hostgroup_host_checks.md
+++ b/src/documentation/developer/externalcommands/enable_hostgroup_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"ENABLE_HOSTGROUP_HOST_CHECKS","description":"Enables active checks for all hosts in a particular hostgroup.","classes":["hostgroup"],"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
+const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"ENABLE_HOSTGROUP_HOST_CHECKS","description":"Enables active checks for all hosts in a particular hostgroup.","classes":["hostgroup"],"commandType":5,"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"E
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_hostgroup_host_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_hostgroup_host_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"ENABLE_HOSTGROUP_HOST_NOTIFICATIONS","description":"Enables notifications for all hosts in a particular hostgroup. This does not enable notifications for the services associated with the hosts in the hostgroup - see the ENABLE_HOSTGROUP_SVC_NOTIFICATIONS command for that. In order for notifications to be sent out for these hosts, notifications must be enabled on a program-wide basis as well.","classes":["hostgroup"],"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
+const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"ENABLE_HOSTGROUP_HOST_NOTIFICATIONS","description":"Enables notifications for all hosts in a particular hostgroup. This does not enable notifications for the services associated with the hosts in the hostgroup - see the ENABLE_HOSTGROUP_SVC_NOTIFICATIONS command for that. In order for notifications to be sent out for these hosts, notifications must be enabled on a program-wide basis as well.","classes":["hostgroup"],"commandType":5,"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"E
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_hostgroup_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/enable_hostgroup_passive_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"ENABLE_HOSTGROUP_PASSIVE_HOST_CHECKS","description":"Enables passive checks for all hosts in a particular hostgroup.","classes":["hostgroup"],"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
+const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"ENABLE_HOSTGROUP_PASSIVE_HOST_CHECKS","description":"Enables passive checks for all hosts in a particular hostgroup.","classes":["hostgroup"],"commandType":5,"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"E
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_hostgroup_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/enable_hostgroup_passive_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"ENABLE_HOSTGROUP_PASSIVE_SVC_CHECKS","description":"Enables passive checks for all services associated with hosts in a particular hostgroup.","classes":["hostgroup","service"],"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
+const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"ENABLE_HOSTGROUP_PASSIVE_SVC_CHECKS","description":"Enables passive checks for all services associated with hosts in a particular hostgroup.","classes":["hostgroup","service"],"commandType":6,"argsStr":";host_name;hostgroup_name","exampleArgStr":";host1;hostgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"E
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_hostgroup_svc_checks.md
+++ b/src/documentation/developer/externalcommands/enable_hostgroup_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"ENABLE_HOSTGROUP_SVC_CHECKS","description":"Enables active checks for all services associated with hosts in a particular hostgroup.","classes":["hostgroup","service"],"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
+const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"ENABLE_HOSTGROUP_SVC_CHECKS","description":"Enables active checks for all services associated with hosts in a particular hostgroup.","classes":["hostgroup","service"],"commandType":6,"argsStr":";host_name;hostgroup_name","exampleArgStr":";host1;hostgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"E
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_hostgroup_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_hostgroup_svc_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"ENABLE_HOSTGROUP_SVC_NOTIFICATIONS","description":"Enables notifications for all services that are associated with hosts in a particular hostgroup. This does not enable notifications for the hosts in the hostgroup - see the ENABLE_HOSTGROUP_HOST_NOTIFICATIONS command for that. In order for notifications to be sent out for these services, notifications must be enabled on a program-wide basis as well.","classes":["hostgroup","service"],"argsStr":";hostgroup_name","exampleArgStr":";hostgroup1"};
+const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"ENABLE_HOSTGROUP_SVC_NOTIFICATIONS","description":"Enables notifications for all services that are associated with hosts in a particular hostgroup. This does not enable notifications for the hosts in the hostgroup - see the ENABLE_HOSTGROUP_HOST_NOTIFICATIONS command for that. In order for notifications to be sent out for these services, notifications must be enabled on a program-wide basis as well.","classes":["hostgroup","service"],"commandType":6,"argsStr":";host_name;hostgroup_name","exampleArgStr":";host1;hostgroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"}],"name":"E
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_notifications.md
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"ENABLE_NOTIFICATIONS","description":"Enables 
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/enable_passive_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_PASSIVE_HOST_CHECKS","description":"Enables acceptance and processing of passive host checks for the specified host.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_PASSIVE_HOST_CHECKS","description":"Enables acceptance and processing of passive host checks for the specified host.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"ENABLE_PASS
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/enable_passive_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_PASSIVE_SVC_CHECKS","description":"Enables passive checks for the specified service.","classes":["service"],"argsStr":";service","exampleArgStr":";service1"};
+const command = {"args":[{"name":"service_description","type":"service"}],"name":"ENABLE_PASSIVE_SVC_CHECKS","description":"Enables passive checks for the specified service.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description","exampleArgStr":";host1;service1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_PAS
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_performance_data.md
+++ b/src/documentation/developer/externalcommands/enable_performance_data.md
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"ENABLE_PERFORMANCE_DATA","description":"Enabl
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_service_freshness_checks.md
+++ b/src/documentation/developer/externalcommands/enable_service_freshness_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"ENABLE_SERVICE_FRESHNESS_CHECKS","description":"Enables freshness checks of all services on a program-wide basis. Individual services that have freshness checks disabled will not be checked for freshness.","classes":["service"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"ENABLE_SERVICE_FRESHNESS_CHECKS","description":"Enables freshness checks of all services on a program-wide basis. Individual services that have freshness checks disabled will not be checked for freshness.","classes":["service"],"commandType":6,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"ENABLE_SERVICE_FRESHNESS_CHECKS","description
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_servicegroup_host_checks.md
+++ b/src/documentation/developer/externalcommands/enable_servicegroup_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"ENABLE_SERVICEGROUP_HOST_CHECKS","description":"Enables active checks for all hosts that have services that are members of a particular hostgroup.","classes":["host","servicegroup"],"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
+const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"ENABLE_SERVICEGROUP_HOST_CHECKS","description":"Enables active checks for all hosts that have services that are members of a particular hostgroup.","classes":["host","servicegroup"],"commandType":7,"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_servicegroup_host_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_servicegroup_host_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS","description":"Enables notifications for all hosts that have services that are members of a particular servicegroup. In order for notifications to be sent out for these hosts, notifications must also be enabled on a program-wide basis.","classes":["host","servicegroup"],"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
+const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS","description":"Enables notifications for all hosts that have services that are members of a particular servicegroup. In order for notifications to be sent out for these hosts, notifications must also be enabled on a program-wide basis.","classes":["host","servicegroup"],"commandType":7,"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_servicegroup_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/enable_servicegroup_passive_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"ENABLE_SERVICEGROUP_PASSIVE_HOST_CHECKS","description":"Enables the acceptance and processing of passive checks for all hosts that have services that are members of a particular service group.","classes":["host","servicegroup"],"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
+const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"ENABLE_SERVICEGROUP_PASSIVE_HOST_CHECKS","description":"Enables the acceptance and processing of passive checks for all hosts that have services that are members of a particular service group.","classes":["host","servicegroup"],"commandType":7,"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_servicegroup_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/enable_servicegroup_passive_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"ENABLE_SERVICEGROUP_PASSIVE_SVC_CHECKS","description":"Enables the acceptance and processing of passive checks for all services in a particular servicegroup.","classes":["servicegroup"],"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
+const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"ENABLE_SERVICEGROUP_PASSIVE_SVC_CHECKS","description":"Enables the acceptance and processing of passive checks for all services in a particular servicegroup.","classes":["servicegroup"],"commandType":7,"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_servicegroup_svc_checks.md
+++ b/src/documentation/developer/externalcommands/enable_servicegroup_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"ENABLE_SERVICEGROUP_SVC_CHECKS","description":"Enables active checks for all services in a particular servicegroup.","classes":["servicegroup"],"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
+const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"ENABLE_SERVICEGROUP_SVC_CHECKS","description":"Enables active checks for all services in a particular servicegroup.","classes":["servicegroup"],"commandType":7,"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_servicegroup_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_servicegroup_svc_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS","description":"Enables notifications for all services that are members of a particular servicegroup. In order for notifications to be sent out for these services, notifications must also be enabled on a program-wide basis.","classes":["servicegroup"],"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
+const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"name":"ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS","description":"Enables notifications for all services that are members of a particular servicegroup. In order for notifications to be sent out for these services, notifications must also be enabled on a program-wide basis.","classes":["servicegroup"],"commandType":7,"argsStr":";servicegroup_name","exampleArgStr":";servicegroup1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"}],"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_svc_check.md
+++ b/src/documentation/developer/externalcommands/enable_svc_check.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_SVC_CHECK","description":"This command is used to enable active checks of a service.","classes":["service"],"argsStr":";service","exampleArgStr":";service1"};
+const command = {"args":[{"name":"service_description","type":"service"}],"name":"ENABLE_SVC_CHECK","description":"This command is used to enable active checks of a service.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description","exampleArgStr":";host1;service1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_SVC
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_svc_event_handler.md
+++ b/src/documentation/developer/externalcommands/enable_svc_event_handler.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_SVC_EVENT_HANDLER","description":"Enables the event handler for the specified service.","classes":["service"],"argsStr":";service","exampleArgStr":";service1"};
+const command = {"args":[{"name":"service_description","type":"service"}],"name":"ENABLE_SVC_EVENT_HANDLER","description":"Enables the event handler for the specified service.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description","exampleArgStr":";host1;service1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_SVC
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_svc_flap_detection.md
+++ b/src/documentation/developer/externalcommands/enable_svc_flap_detection.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_SVC_FLAP_DETECTION","description":"Enables flap detection for the specified service. In order for the flap detection algorithms to be run for the service, flap detection must be enabled on a program-wide basis as well.","classes":["service"],"argsStr":";service","exampleArgStr":";service1"};
+const command = {"args":[{"name":"service_description","type":"service"}],"name":"ENABLE_SVC_FLAP_DETECTION","description":"Enables flap detection for the specified service. In order for the flap detection algorithms to be run for the service, flap detection must be enabled on a program-wide basis as well.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description","exampleArgStr":";host1;service1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_SVC
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/enable_svc_notifications.md
+++ b/src/documentation/developer/externalcommands/enable_svc_notifications.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_SVC_NOTIFICATIONS","description":"Enables notifications for a particular service. Notifications will be sent out for the service only if notifications are enabled on a program-wide basis as well.","classes":["service"],"argsStr":";service","exampleArgStr":";service1"};
+const command = {"args":[{"name":"service_description","type":"service"}],"name":"ENABLE_SVC_NOTIFICATIONS","description":"Enables notifications for a particular service. Notifications will be sent out for the service only if notifications are enabled on a program-wide basis as well.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description","exampleArgStr":";host1;service1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"ENABLE_SVC
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/log.md
+++ b/src/documentation/developer/externalcommands/log.md
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"LOG","description":"Adds custom entry to the 
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/process_file.md
+++ b/src/documentation/developer/externalcommands/process_file.md
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"file_name","type":"str"},{"name":"delete","typ
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/process_host_check_result.md
+++ b/src/documentation/developer/externalcommands/process_host_check_result.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"status_code","type":"int"},{"name":"plugin_output","type":"str"}],"name":"PROCESS_HOST_CHECK_RESULT","description":"This is used to submit a passive check result for a particular host. The 'status_code' indicates the state of the host check and should be one of the following: 0=UP, 1=DOWN, 2=UNREACHABLE. The 'plugin_output' argument contains the text returned from the host check, along with optional performance data.","classes":["host"],"argsStr":";host_name;status_code;plugin_output","exampleArgStr":";host1;0;This is an example plugin output."};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"status_code","type":"int"},{"name":"plugin_output","type":"str"}],"name":"PROCESS_HOST_CHECK_RESULT","description":"This is used to submit a passive check result for a particular host. The 'status_code' indicates the state of the host check and should be one of the following: 0=UP, 1=DOWN, 2=UNREACHABLE. The 'plugin_output' argument contains the text returned from the host check, along with optional performance data.","classes":["host"],"commandType":4,"argsStr":";host_name;status_code;plugin_output","exampleArgStr":";host1;0;This is an example plugin output."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"status_code
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/process_service_check_result.md
+++ b/src/documentation/developer/externalcommands/process_service_check_result.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"status_code","type":"int"},{"name":"plugin_output","type":"str"}],"name":"PROCESS_SERVICE_CHECK_RESULT","description":"This is used to submit a passive check result for a particular service. The 'status_code' field should be one of the following: 0=OK, 1=WARNING, 2=CRITICAL, 3=UNKNOWN. The 'plugin_output' field contains text output from the service check, along with optional performance data.","classes":["service"],"argsStr":";service;status_code;plugin_output","exampleArgStr":";service1;0;This is an example plugin output."};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"status_code","type":"int"},{"name":"plugin_output","type":"str"}],"name":"PROCESS_SERVICE_CHECK_RESULT","description":"This is used to submit a passive check result for a particular service. The 'status_code' field should be one of the following: 0=OK, 1=WARNING, 2=CRITICAL, 3=UNKNOWN. The 'plugin_output' field contains text output from the service check, along with optional performance data.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description;status_code;plugin_output","exampleArgStr":";host1;service1;0;This is an example plugin output."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"status_cod
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/read_state_information.md
+++ b/src/documentation/developer/externalcommands/read_state_information.md
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"READ_STATE_INFORMATION","description":"Causes
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/remove_host_acknowledgement.md
+++ b/src/documentation/developer/externalcommands/remove_host_acknowledgement.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"REMOVE_HOST_ACKNOWLEDGEMENT","description":"This removes the problem acknowledgement for a particular host. Once the acknowledgement has been removed, notifications can once again be sent out for the given host.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"REMOVE_HOST_ACKNOWLEDGEMENT","description":"This removes the problem acknowledgement for a particular host. Once the acknowledgement has been removed, notifications can once again be sent out for the given host.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"REMOVE_HOST
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/remove_svc_acknowledgement.md
+++ b/src/documentation/developer/externalcommands/remove_svc_acknowledgement.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"}],"name":"REMOVE_SVC_ACKNOWLEDGEMENT","description":"This removes the problem acknowledgement for a particular service. Once the acknowledgement has been removed, notifications can once again be sent out for the given service.","classes":["service"],"argsStr":";service","exampleArgStr":";service1"};
+const command = {"args":[{"name":"service_description","type":"service"}],"name":"REMOVE_SVC_ACKNOWLEDGEMENT","description":"This removes the problem acknowledgement for a particular service. Once the acknowledgement has been removed, notifications can once again be sent out for the given service.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description","exampleArgStr":";host1;service1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"REMOVE_SVC
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/restart_process.md
+++ b/src/documentation/developer/externalcommands/restart_process.md
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"RESTART_PROCESS","description":"Restarts the 
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/restart_program.md
+++ b/src/documentation/developer/externalcommands/restart_program.md
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"RESTART_PROGRAM","description":"Restarts the 
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/save_state_information.md
+++ b/src/documentation/developer/externalcommands/save_state_information.md
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"SAVE_STATE_INFORMATION","description":"Causes
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_and_propagate_host_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_and_propagate_host_downtime.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_AND_PROPAGATE_HOST_DOWNTIME","description":"Schedules downtime for a specified host and all of its children (hosts). If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The specified (parent) host downtime can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the specified (parent) host should not be triggered by another downtime entry.","classes":["host","downtime"],"argsStr":";host_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";host1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_AND_PROPAGATE_HOST_DOWNTIME","description":"Schedules downtime for a specified host and all of its children (hosts). If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The specified (parent) host downtime can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the specified (parent) host should not be triggered by another downtime entry.","classes":["host","downtime"],"commandType":4,"argsStr":";host_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";host1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time"
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_and_propagate_triggered_host_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_and_propagate_triggered_host_downtime.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_AND_PROPAGATE_TRIGGERED_HOST_DOWNTIME","description":"Schedules downtime for a specified host and all of its children (hosts). If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). Downtime for child hosts are all set to be triggered by the downtime for the specified (parent) host. The specified (parent) host downtime can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the specified (parent) host should not be triggered by another downtime entry.","classes":["host","downtime"],"argsStr":";host_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";host1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_AND_PROPAGATE_TRIGGERED_HOST_DOWNTIME","description":"Schedules downtime for a specified host and all of its children (hosts). If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). Downtime for child hosts are all set to be triggered by the downtime for the specified (parent) host. The specified (parent) host downtime can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the specified (parent) host should not be triggered by another downtime entry.","classes":["host","downtime"],"commandType":4,"argsStr":";host_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";host1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time"
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_forced_host_check.md
+++ b/src/documentation/developer/externalcommands/schedule_forced_host_check.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time","type":"timestamp"}],"name":"SCHEDULE_FORCED_HOST_CHECK","description":"Schedules a forced active check of a particular host at 'check_time'. The 'check_time' argument is specified in time_t format (seconds since the UNIX epoch). Forced checks are performed regardless of what time it is (e.g. timeperiod restrictions are ignored) and whether or not active checks are enabled on a host-specific or program-wide basis.","classes":["host"],"argsStr":";host_name;check_time","exampleArgStr":";host1;1478648441"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time","type":"timestamp"}],"name":"SCHEDULE_FORCED_HOST_CHECK","description":"Schedules a forced active check of a particular host at 'check_time'. The 'check_time' argument is specified in time_t format (seconds since the UNIX epoch). Forced checks are performed regardless of what time it is (e.g. timeperiod restrictions are ignored) and whether or not active checks are enabled on a host-specific or program-wide basis.","classes":["host"],"commandType":4,"argsStr":";host_name;check_time","exampleArgStr":";host1;1478648441"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time"
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_forced_host_svc_checks.md
+++ b/src/documentation/developer/externalcommands/schedule_forced_host_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time","type":"timestamp"}],"name":"SCHEDULE_FORCED_HOST_SVC_CHECKS","description":"Schedules a forced active check of all services associated with a particular host at 'check_time'. The 'check_time' argument is specified in time_t format (seconds since the UNIX epoch). Forced checks are performed regardless of what time it is (e.g. timeperiod restrictions are ignored) and whether or not active checks are enabled on a service-specific or program-wide basis.","classes":["host","service"],"argsStr":";host_name;check_time","exampleArgStr":";host1;1478648441"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time","type":"timestamp"}],"name":"SCHEDULE_FORCED_HOST_SVC_CHECKS","description":"Schedules a forced active check of all services associated with a particular host at 'check_time'. The 'check_time' argument is specified in time_t format (seconds since the UNIX epoch). Forced checks are performed regardless of what time it is (e.g. timeperiod restrictions are ignored) and whether or not active checks are enabled on a service-specific or program-wide basis.","classes":["host","service"],"commandType":6,"argsStr":";host_name;host_name;check_time","exampleArgStr":";host1;host1;1478648441"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time"
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_forced_svc_check.md
+++ b/src/documentation/developer/externalcommands/schedule_forced_svc_check.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"check_time","type":"timestamp"}],"name":"SCHEDULE_FORCED_SVC_CHECK","description":"Schedules a forced active check of a particular service at 'check_time'. The 'check_time' argument is specified in time_t format (seconds since the UNIX epoch). Forced checks are performed regardless of what time it is (e.g. timeperiod restrictions are ignored) and whether or not active checks are enabled on a service-specific or program-wide basis.","classes":["service"],"argsStr":";service;check_time","exampleArgStr":";service1;1478648441"};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"check_time","type":"timestamp"}],"name":"SCHEDULE_FORCED_SVC_CHECK","description":"Schedules a forced active check of a particular service at 'check_time'. The 'check_time' argument is specified in time_t format (seconds since the UNIX epoch). Forced checks are performed regardless of what time it is (e.g. timeperiod restrictions are ignored) and whether or not active checks are enabled on a service-specific or program-wide basis.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description;check_time","exampleArgStr":";host1;service1;1478648441"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"check_time
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_host_check.md
+++ b/src/documentation/developer/externalcommands/schedule_host_check.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time","type":"timestamp"}],"name":"SCHEDULE_HOST_CHECK","description":"Schedules the next active check of a particular host at 'check_time'. The 'check_time' argument is specified in time_t format (seconds since the UNIX epoch). Note that the host may not actually be checked at the time you specify. This could occur for a number of reasons: active checks are disabled on a program-wide or service-specific basis, the host is already scheduled to be checked at an earlier time, etc. If you want to force the host check to occur at the time you specify, look at the SCHEDULE_FORCED_HOST_CHECK command.","classes":["host"],"argsStr":";host_name;check_time","exampleArgStr":";host1;1478648441"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time","type":"timestamp"}],"name":"SCHEDULE_HOST_CHECK","description":"Schedules the next active check of a particular host at 'check_time'. The 'check_time' argument is specified in time_t format (seconds since the UNIX epoch). Note that the host may not actually be checked at the time you specify. This could occur for a number of reasons: active checks are disabled on a program-wide or service-specific basis, the host is already scheduled to be checked at an earlier time, etc. If you want to force the host check to occur at the time you specify, look at the SCHEDULE_FORCED_HOST_CHECK command.","classes":["host"],"commandType":4,"argsStr":";host_name;check_time","exampleArgStr":";host1;1478648441"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time"
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_host_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_host_downtime.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_HOST_DOWNTIME","description":"Schedules downtime for a specified host. If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The specified host downtime can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the specified host should not be triggered by another downtime entry.","classes":["host","downtime"],"argsStr":";host_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";host1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_HOST_DOWNTIME","description":"Schedules downtime for a specified host. If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The specified host downtime can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the specified host should not be triggered by another downtime entry.","classes":["host","downtime"],"commandType":4,"argsStr":";host_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";host1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time"
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_host_svc_checks.md
+++ b/src/documentation/developer/externalcommands/schedule_host_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time","type":"timestamp"}],"name":"SCHEDULE_HOST_SVC_CHECKS","description":"Schedules the next active check of all services on a particular host at 'check_time'. The 'check_time' argument is specified in time_t format (seconds since the UNIX epoch). Note that the services may not actually be checked at the time you specify. This could occur for a number of reasons: active checks are disabled on a program-wide or service-specific basis, the services are already scheduled to be checked at an earlier time, etc. If you want to force the service checks to occur at the time you specify, look at the SCHEDULE_FORCED_HOST_SVC_CHECKS command.","classes":["host","service"],"argsStr":";host_name;check_time","exampleArgStr":";host1;1478648441"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time","type":"timestamp"}],"name":"SCHEDULE_HOST_SVC_CHECKS","description":"Schedules the next active check of all services on a particular host at 'check_time'. The 'check_time' argument is specified in time_t format (seconds since the UNIX epoch). Note that the services may not actually be checked at the time you specify. This could occur for a number of reasons: active checks are disabled on a program-wide or service-specific basis, the services are already scheduled to be checked at an earlier time, etc. If you want to force the service checks to occur at the time you specify, look at the SCHEDULE_FORCED_HOST_SVC_CHECKS command.","classes":["host","service"],"commandType":6,"argsStr":";host_name;host_name;check_time","exampleArgStr":";host1;host1;1478648441"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"check_time"
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_host_svc_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_host_svc_downtime.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_HOST_SVC_DOWNTIME","description":"Schedules downtime for all services associated with a particular host. If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The service downtime entries can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the services should not be triggered by another downtime entry.","classes":["host","service","downtime"],"argsStr":";host_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";host1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_HOST_SVC_DOWNTIME","description":"Schedules downtime for all services associated with a particular host. If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The service downtime entries can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the services should not be triggered by another downtime entry.","classes":["host","service","downtime"],"commandType":6,"argsStr":";host_name;host_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";host1;host1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"start_time"
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_hostgroup_host_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_hostgroup_host_downtime.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_HOSTGROUP_HOST_DOWNTIME","description":"Schedules downtime for all hosts in a specified hostgroup. If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The host downtime entries can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the hosts should not be triggered by another downtime entry.","classes":["hostgroup","downtime"],"argsStr":";hostgroup_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";hostgroup1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_HOSTGROUP_HOST_DOWNTIME","description":"Schedules downtime for all hosts in a specified hostgroup. If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The host downtime entries can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the hosts should not be triggered by another downtime entry.","classes":["hostgroup","downtime"],"commandType":5,"argsStr":";hostgroup_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";hostgroup1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"},{"name":"s
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_hostgroup_svc_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_hostgroup_svc_downtime.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_HOSTGROUP_SVC_DOWNTIME","description":"Schedules downtime for all services associated with hosts in a specified servicegroup. If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The service downtime entries can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the services should not be triggered by another downtime entry.","classes":["hostgroup","service","downtime"],"argsStr":";hostgroup_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";hostgroup1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_HOSTGROUP_SVC_DOWNTIME","description":"Schedules downtime for all services associated with hosts in a specified servicegroup. If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The service downtime entries can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the services should not be triggered by another downtime entry.","classes":["hostgroup","service","downtime"],"commandType":6,"argsStr":";host_name;hostgroup_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";host1;hostgroup1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"hostgroup_name","type":"hostgroup"},{"name":"s
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_servicegroup_host_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_servicegroup_host_downtime.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_SERVICEGROUP_HOST_DOWNTIME","description":"Schedules downtime for all hosts that have services in a specified servicegroup. If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The host downtime entries can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the hosts should not be triggered by another downtime entry.","classes":["host","servicegroup","downtime"],"argsStr":";servicegroup_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";servicegroup1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_SERVICEGROUP_HOST_DOWNTIME","description":"Schedules downtime for all hosts that have services in a specified servicegroup. If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The host downtime entries can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the hosts should not be triggered by another downtime entry.","classes":["host","servicegroup","downtime"],"commandType":7,"argsStr":";servicegroup_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";servicegroup1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"},{"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_servicegroup_svc_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_servicegroup_svc_downtime.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_SERVICEGROUP_SVC_DOWNTIME","description":"Schedules downtime for all services in a specified servicegroup. If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The service downtime entries can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the services should not be triggered by another downtime entry.","classes":["servicegroup","downtime"],"argsStr":";servicegroup_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";servicegroup1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_SERVICEGROUP_SVC_DOWNTIME","description":"Schedules downtime for all services in a specified servicegroup. If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The service downtime entries can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the services should not be triggered by another downtime entry.","classes":["servicegroup","downtime"],"commandType":7,"argsStr":";servicegroup_name;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";servicegroup1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"servicegroup_name","type":"servicegroup"},{"na
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_svc_check.md
+++ b/src/documentation/developer/externalcommands/schedule_svc_check.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"check_time","type":"timestamp"}],"name":"SCHEDULE_SVC_CHECK","description":"Schedules the next active check of a specified service at 'check_time'. The 'check_time' argument is specified in time_t format (seconds since the UNIX epoch). Note that the service may not actually be checked at the time you specify. This could occur for a number of reasons: active checks are disabled on a program-wide or service-specific basis, the service is already scheduled to be checked at an earlier time, etc. If you want to force the service check to occur at the time you specify, look at the SCHEDULE_FORCED_SVC_CHECK command.","classes":["service"],"argsStr":";service;check_time","exampleArgStr":";service1;1478648441"};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"check_time","type":"timestamp"}],"name":"SCHEDULE_SVC_CHECK","description":"Schedules the next active check of a specified service at 'check_time'. The 'check_time' argument is specified in time_t format (seconds since the UNIX epoch). Note that the service may not actually be checked at the time you specify. This could occur for a number of reasons: active checks are disabled on a program-wide or service-specific basis, the service is already scheduled to be checked at an earlier time, etc. If you want to force the service check to occur at the time you specify, look at the SCHEDULE_FORCED_SVC_CHECK command.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description;check_time","exampleArgStr":";host1;service1;1478648441"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"check_time
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/schedule_svc_downtime.md
+++ b/src/documentation/developer/externalcommands/schedule_svc_downtime.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_SVC_DOWNTIME","description":"Schedules downtime for a specified service. If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The specified service downtime can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the specified service should not be triggered by another downtime entry.","classes":["service","downtime"],"argsStr":";service;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";service1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"start_time","type":"timestamp"},{"name":"end_time","type":"timestamp"},{"name":"fixed","type":"bool"},{"name":"trigger_id","type":"ulong"},{"name":"duration","type":"ulong"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SCHEDULE_SVC_DOWNTIME","description":"Schedules downtime for a specified service. If the 'fixed' argument is set to one (1), downtime will start and end at the times specified by the 'start' and 'end' arguments. Otherwise, downtime will begin between the 'start' and 'end' times and last for 'duration' seconds. The 'start' and 'end' arguments are specified in time_t format (seconds since the UNIX epoch). The specified service downtime can be triggered by another downtime entry if the 'trigger_id' is set to the ID of another scheduled downtime entry. Set the 'trigger_id' argument to zero (0) if the downtime for the specified service should not be triggered by another downtime entry.","classes":["service","downtime"],"commandType":6,"argsStr":";host_name;service_description;start_time;end_time;fixed;trigger_id;duration;author;comment","exampleArgStr":";host1;service1;1478648441;1478638441;1;0;3600;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"start_time
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/send_custom_host_notification.md
+++ b/src/documentation/developer/externalcommands/send_custom_host_notification.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"options","type":"int"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SEND_CUSTOM_HOST_NOTIFICATION","description":"Allows you to send a custom host notification. Very useful in dire situations, emergencies or to communicate with all admins that are responsible for a particular host. When the host notification is sent out, the $NOTIFICATIONTYPE$ macro will be set to 'CUSTOM'. The <options> field is a logical OR of the following integer values that affect aspects of the notification that are sent out: 0 = No option (default), 1 = Broadcast (send notification to all normal and all escalated contacts for the host), 2 = Forced (notification is sent out regardless of current time, whether or not notifications are enabled, etc.), 4 = Increment current notification # for the host (this is not done by default for custom notifications). The comment field can be used with the $NOTIFICATIONCOMMENT$ macro in notification commands.","classes":["host","comment"],"argsStr":";host_name;options;author;comment","exampleArgStr":";host1;0;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"options","type":"int"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SEND_CUSTOM_HOST_NOTIFICATION","description":"Allows you to send a custom host notification. Very useful in dire situations, emergencies or to communicate with all admins that are responsible for a particular host. When the host notification is sent out, the $NOTIFICATIONTYPE$ macro will be set to 'CUSTOM'. The <options> field is a logical OR of the following integer values that affect aspects of the notification that are sent out: 0 = No option (default), 1 = Broadcast (send notification to all normal and all escalated contacts for the host), 2 = Forced (notification is sent out regardless of current time, whether or not notifications are enabled, etc.), 4 = Increment current notification # for the host (this is not done by default for custom notifications). The comment field can be used with the $NOTIFICATIONCOMMENT$ macro in notification commands.","classes":["host","comment"],"commandType":4,"argsStr":";host_name;options;author;comment","exampleArgStr":";host1;0;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"options","t
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/send_custom_svc_notification.md
+++ b/src/documentation/developer/externalcommands/send_custom_svc_notification.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"options","type":"int"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SEND_CUSTOM_SVC_NOTIFICATION","description":"Allows you to send a custom service notification. Very useful in dire situations, emergencies or to communicate with all admins that are responsible for a particular service. When the service notification is sent out, the $NOTIFICATIONTYPE$ macro will be set to 'CUSTOM'. The <options> field is a logical OR of the following integer values that affect aspects of the notification that are sent out: 0 = No option (default), 1 = Broadcast (send notification to all normal and all escalated contacts for the service), 2 = Forced (notification is sent out regardless of current time, whether or not notifications are enabled, etc.), 4 = Increment current notification # for the service(this is not done by default for custom notifications)","classes":["service","comment"],"argsStr":";service;options;author;comment","exampleArgStr":";service1;0;naemonadmin;This is an example comment."};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"options","type":"int"},{"name":"author","type":"str"},{"name":"comment","type":"str"}],"name":"SEND_CUSTOM_SVC_NOTIFICATION","description":"Allows you to send a custom service notification. Very useful in dire situations, emergencies or to communicate with all admins that are responsible for a particular service. When the service notification is sent out, the $NOTIFICATIONTYPE$ macro will be set to 'CUSTOM'. The <options> field is a logical OR of the following integer values that affect aspects of the notification that are sent out: 0 = No option (default), 1 = Broadcast (send notification to all normal and all escalated contacts for the service), 2 = Forced (notification is sent out regardless of current time, whether or not notifications are enabled, etc.), 4 = Increment current notification # for the service(this is not done by default for custom notifications)","classes":["service","comment"],"commandType":6,"argsStr":";host_name;service_description;options;author;comment","exampleArgStr":";host1;service1;0;naemonadmin;This is an example comment."};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"options","
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/set_host_notification_number.md
+++ b/src/documentation/developer/externalcommands/set_host_notification_number.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"},{"name":"notification_number","type":"int"}],"name":"SET_HOST_NOTIFICATION_NUMBER","description":"Sets the current notification number for a particular host. A value of 0 indicates that no notification has yet been sent for the current host problem. Useful for forcing an escalation (based on notification number) or replicating notification information in redundant monitoring environments. Notification numbers greater than zero have no noticeable affect on the notification process if the host is currently in an UP state.","classes":["host","notification"],"argsStr":";host_name;notification_number","exampleArgStr":";host1;0"};
+const command = {"args":[{"name":"host_name","type":"host"},{"name":"notification_number","type":"int"}],"name":"SET_HOST_NOTIFICATION_NUMBER","description":"Sets the current notification number for a particular host. A value of 0 indicates that no notification has yet been sent for the current host problem. Useful for forcing an escalation (based on notification number) or replicating notification information in redundant monitoring environments. Notification numbers greater than zero have no noticeable affect on the notification process if the host is currently in an UP state.","classes":["host","notification"],"commandType":4,"argsStr":";host_name;notification_number","exampleArgStr":";host1;0"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"},{"name":"notificatio
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/set_svc_notification_number.md
+++ b/src/documentation/developer/externalcommands/set_svc_notification_number.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"},{"name":"notification_number","type":"int"}],"name":"SET_SVC_NOTIFICATION_NUMBER","description":"Sets the current notification number for a particular service. A value of 0 indicates that no notification has yet been sent for the current service problem. Useful for forcing an escalation (based on notification number) or replicating notification information in redundant monitoring environments. Notification numbers greater than zero have no noticeable affect on the notification process if the service is currently in an OK state.","classes":["service","notification"],"argsStr":";service;notification_number","exampleArgStr":";service1;0"};
+const command = {"args":[{"name":"service_description","type":"service"},{"name":"notification_number","type":"int"}],"name":"SET_SVC_NOTIFICATION_NUMBER","description":"Sets the current notification number for a particular service. A value of 0 indicates that no notification has yet been sent for the current service problem. Useful for forcing an escalation (based on notification number) or replicating notification information in redundant monitoring environments. Notification numbers greater than zero have no noticeable affect on the notification process if the service is currently in an OK state.","classes":["service","notification"],"commandType":6,"argsStr":";host_name;service_description;notification_number","exampleArgStr":";host1;service1;0"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"},{"name":"notificati
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/shutdown_process.md
+++ b/src/documentation/developer/externalcommands/shutdown_process.md
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"SHUTDOWN_PROCESS","description":"Shuts down t
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/shutdown_program.md
+++ b/src/documentation/developer/externalcommands/shutdown_program.md
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"SHUTDOWN_PROGRAM","description":"Shuts down t
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_accepting_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/start_accepting_passive_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"START_ACCEPTING_PASSIVE_HOST_CHECKS","description":"Enables acceptance and processing of passive host checks on a program-wide basis.","classes":["host"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"START_ACCEPTING_PASSIVE_HOST_CHECKS","description":"Enables acceptance and processing of passive host checks on a program-wide basis.","classes":["host"],"commandType":4,"argsStr":"","exampleArgStr":""};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"START_ACCEPTING_PASSIVE_HOST_CHECKS","descrip
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_accepting_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/start_accepting_passive_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"START_ACCEPTING_PASSIVE_SVC_CHECKS","description":"Enables passive service checks on a program-wide basis.","classes":["service"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"START_ACCEPTING_PASSIVE_SVC_CHECKS","description":"Enables passive service checks on a program-wide basis.","classes":["service"],"commandType":6,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"START_ACCEPTING_PASSIVE_SVC_CHECKS","descript
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_executing_host_checks.md
+++ b/src/documentation/developer/externalcommands/start_executing_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"START_EXECUTING_HOST_CHECKS","description":"Enables active host checks on a program-wide basis.","classes":["host"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"START_EXECUTING_HOST_CHECKS","description":"Enables active host checks on a program-wide basis.","classes":["host"],"commandType":4,"argsStr":"","exampleArgStr":""};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"START_EXECUTING_HOST_CHECKS","description":"E
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_executing_svc_checks.md
+++ b/src/documentation/developer/externalcommands/start_executing_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"START_EXECUTING_SVC_CHECKS","description":"Enables active checks of services on a program-wide basis.","classes":["service"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"START_EXECUTING_SVC_CHECKS","description":"Enables active checks of services on a program-wide basis.","classes":["service"],"commandType":6,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"START_EXECUTING_SVC_CHECKS","description":"En
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_obsessing_over_host.md
+++ b/src/documentation/developer/externalcommands/start_obsessing_over_host.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"START_OBSESSING_OVER_HOST","description":"Enables processing of host checks via the OCHP command for the specified host.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"START_OBSESSING_OVER_HOST","description":"Enables processing of host checks via the OCHP command for the specified host.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"START_OBSES
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_obsessing_over_host_checks.md
+++ b/src/documentation/developer/externalcommands/start_obsessing_over_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"START_OBSESSING_OVER_HOST_CHECKS","description":"Enables processing of host checks via the OCHP command on a program-wide basis.","classes":["host"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"START_OBSESSING_OVER_HOST_CHECKS","description":"Enables processing of host checks via the OCHP command on a program-wide basis.","classes":["host"],"commandType":4,"argsStr":"","exampleArgStr":""};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"START_OBSESSING_OVER_HOST_CHECKS","descriptio
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_obsessing_over_svc.md
+++ b/src/documentation/developer/externalcommands/start_obsessing_over_svc.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"}],"name":"START_OBSESSING_OVER_SVC","description":"Enables processing of service checks via the OCSP command for the specified service.","classes":["service"],"argsStr":";service","exampleArgStr":";service1"};
+const command = {"args":[{"name":"service_description","type":"service"}],"name":"START_OBSESSING_OVER_SVC","description":"Enables processing of service checks via the OCSP command for the specified service.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description","exampleArgStr":";host1;service1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"START_OBSE
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/start_obsessing_over_svc_checks.md
+++ b/src/documentation/developer/externalcommands/start_obsessing_over_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"START_OBSESSING_OVER_SVC_CHECKS","description":"Enables processing of service checks via the OCSP command on a program-wide basis.","classes":["service"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"START_OBSESSING_OVER_SVC_CHECKS","description":"Enables processing of service checks via the OCSP command on a program-wide basis.","classes":["service"],"commandType":6,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"START_OBSESSING_OVER_SVC_CHECKS","description
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_accepting_passive_host_checks.md
+++ b/src/documentation/developer/externalcommands/stop_accepting_passive_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"STOP_ACCEPTING_PASSIVE_HOST_CHECKS","description":"Disables acceptance and processing of passive host checks on a program-wide basis.","classes":["host"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"STOP_ACCEPTING_PASSIVE_HOST_CHECKS","description":"Disables acceptance and processing of passive host checks on a program-wide basis.","classes":["host"],"commandType":4,"argsStr":"","exampleArgStr":""};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"STOP_ACCEPTING_PASSIVE_HOST_CHECKS","descript
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_accepting_passive_svc_checks.md
+++ b/src/documentation/developer/externalcommands/stop_accepting_passive_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"STOP_ACCEPTING_PASSIVE_SVC_CHECKS","description":"Disables passive service checks on a program-wide basis.","classes":["service"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"STOP_ACCEPTING_PASSIVE_SVC_CHECKS","description":"Disables passive service checks on a program-wide basis.","classes":["service"],"commandType":6,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"STOP_ACCEPTING_PASSIVE_SVC_CHECKS","descripti
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_executing_host_checks.md
+++ b/src/documentation/developer/externalcommands/stop_executing_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"STOP_EXECUTING_HOST_CHECKS","description":"Disables active host checks on a program-wide basis.","classes":["host"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"STOP_EXECUTING_HOST_CHECKS","description":"Disables active host checks on a program-wide basis.","classes":["host"],"commandType":4,"argsStr":"","exampleArgStr":""};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"STOP_EXECUTING_HOST_CHECKS","description":"Di
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_executing_svc_checks.md
+++ b/src/documentation/developer/externalcommands/stop_executing_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"STOP_EXECUTING_SVC_CHECKS","description":"Disables active checks of services on a program-wide basis.","classes":["service"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"STOP_EXECUTING_SVC_CHECKS","description":"Disables active checks of services on a program-wide basis.","classes":["service"],"commandType":6,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"STOP_EXECUTING_SVC_CHECKS","description":"Dis
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_obsessing_over_host.md
+++ b/src/documentation/developer/externalcommands/stop_obsessing_over_host.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"host_name","type":"host"}],"name":"STOP_OBSESSING_OVER_HOST","description":"Disables processing of host checks via the OCHP command for the specified host.","classes":["host"],"argsStr":";host_name","exampleArgStr":";host1"};
+const command = {"args":[{"name":"host_name","type":"host"}],"name":"STOP_OBSESSING_OVER_HOST","description":"Disables processing of host checks via the OCHP command for the specified host.","classes":["host"],"commandType":4,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"host_name","type":"host"}],"name":"STOP_OBSESS
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_obsessing_over_host_checks.md
+++ b/src/documentation/developer/externalcommands/stop_obsessing_over_host_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"STOP_OBSESSING_OVER_HOST_CHECKS","description":"Disables processing of host checks via the OCHP command on a program-wide basis.","classes":["host"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"STOP_OBSESSING_OVER_HOST_CHECKS","description":"Disables processing of host checks via the OCHP command on a program-wide basis.","classes":["host"],"commandType":4,"argsStr":"","exampleArgStr":""};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"STOP_OBSESSING_OVER_HOST_CHECKS","description
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_obsessing_over_svc.md
+++ b/src/documentation/developer/externalcommands/stop_obsessing_over_svc.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[{"name":"service","type":"service"}],"name":"STOP_OBSESSING_OVER_SVC","description":"Disables processing of service checks via the OCSP command for the specified service.","classes":["service"],"argsStr":";service","exampleArgStr":";service1"};
+const command = {"args":[{"name":"service_description","type":"service"}],"name":"STOP_OBSESSING_OVER_SVC","description":"Disables processing of service checks via the OCSP command for the specified service.","classes":["service"],"commandType":6,"argsStr":";host_name;service_description","exampleArgStr":";host1;service1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[{"name":"service","type":"service"}],"name":"STOP_OBSES
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```

--- a/src/documentation/developer/externalcommands/stop_obsessing_over_svc_checks.md
+++ b/src/documentation/developer/externalcommands/stop_obsessing_over_svc_checks.md
@@ -9,7 +9,7 @@ aside: false
 ---
 
 <script setup>
-const command = {"args":[],"name":"STOP_OBSESSING_OVER_SVC_CHECKS","description":"Disables processing of service checks via the OCSP command on a program-wide basis.","classes":["service"],"argsStr":"","exampleArgStr":""};
+const command = {"args":[],"name":"STOP_OBSESSING_OVER_SVC_CHECKS","description":"Disables processing of service checks via the OCSP command on a program-wide basis.","classes":["service"],"commandType":6,"argsStr":";host_name","exampleArgStr":";host1"};
 </script>
 
 <h3>{{ command.name.replace(/_/g, " ") }}</h3>
@@ -28,7 +28,7 @@ const command = {"args":[],"name":"STOP_OBSESSING_OVER_SVC_CHECKS","description"
 #!/bin/sh
 # This is a shell script showing how to submit the {{ command.name }} command
 # to Naemon. Adjust variables to fit your environment as necessary.
-
+{{ command?.additionalInformation  }}
 printf "[%lu] {{ command.name }}{{ command.exampleArgStr }}\n" \
     `date +%s` > /var/lib/naemon/naemon.cmd
 ```


### PR DESCRIPTION
Improve examples for changing custom variables

The generator got improved so we dont have to do this changes manually in the future. The docs should now be compatible to https://github.com/naemon/naemon.github.io/tree/bootstrap_legacy/documentation/developer/externalcommands